### PR TITLE
Update PlatformIO library dependencies

### DIFF
--- a/.github/agents.md
+++ b/.github/agents.md
@@ -169,8 +169,15 @@ support tooling used by the embedded project.
 - Before changing versions, search for version declarations and report the
   candidate files found.
 - If multiple version declarations exist, report them before changing versions.
+- Bump library or project version declarations for dependency and build metadata
+  changes. Do not automatically bump independent example firmware or app
+  versions.
+- Bump an example firmware or app version only when that example itself is
+  intentionally changed or released.
 - If the version source of truth is unclear, stop and report candidate files
   instead of guessing.
+- If version ownership is unclear, stop and report candidate files instead of
+  guessing.
 
 ## Session-Close Workflow
 

--- a/.github/agents/refactor.agent.md
+++ b/.github/agents/refactor.agent.md
@@ -53,8 +53,15 @@ Version Handling:
 - Before changing versions, search for version declarations and report the
   candidate files found.
 - If multiple version declarations exist, report them before changing versions.
+- Bump library or project version declarations for dependency and build metadata
+  changes. Do not automatically bump independent example firmware or app
+  versions.
+- Bump an example firmware or app version only when that example itself is
+  intentionally changed or released.
 - If the version source of truth is unclear, stop and report candidate files
   instead of guessing.
+- If version ownership is unclear, stop and report candidate files instead of
+  guessing.
 
 Rename Safety:
 

--- a/examples/SolarInverterLimiter/platformio.ini
+++ b/examples/SolarInverterLimiter/platformio.ini
@@ -34,7 +34,7 @@ lib_deps =
 	adafruit/Adafruit SSD1306@^2.5.13
 	adafruit/Adafruit GFX Library@1.12.6
 	bblanchon/ArduinoJson@7.4.3
-	esphome/ESPAsyncWebServer-esphome@^3.2.2
+	esphome/ESPAsyncWebServer-esphome@^3.4.0
 	vitaly.ruhl/ESP32 Configuration Manager@^4.0.0
 	; C:\Daten\_Codding\ESP32\ConfigurationsManager
 test_ignore = src/main.cpp
@@ -61,7 +61,7 @@ lib_deps =
 	adafruit/Adafruit SSD1306@^2.5.13
 	adafruit/Adafruit GFX Library@1.12.6
 	bblanchon/ArduinoJson@7.4.3
-	esphome/ESPAsyncWebServer-esphome@^3.2.2
+	esphome/ESPAsyncWebServer-esphome@^3.4.0
 	vitaly.ruhl/ESP32 Configuration Manager@^4.0.0
 	; C:\Daten\_Codding\ESP32\ConfigurationsManager
 test_ignore = src/main.cpp

--- a/examples/SolarInverterLimiter/src/main.cpp
+++ b/examples/SolarInverterLimiter/src/main.cpp
@@ -58,7 +58,7 @@
 #endif
 
 #ifndef VERSION
-#define VERSION "4.1.2"
+#define VERSION "4.1.1"
 #endif
 
 enum class NegativePriceSettingPreference : uint8_t

--- a/examples/SolarInverterLimiter/src/main.cpp
+++ b/examples/SolarInverterLimiter/src/main.cpp
@@ -58,7 +58,7 @@
 #endif
 
 #ifndef VERSION
-#define VERSION "4.1.1"
+#define VERSION "4.1.2"
 #endif
 
 enum class NegativePriceSettingPreference : uint8_t

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32 Configuration Manager",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "keywords": "esp32, configuration, wifi, web-server, ota, iot, automation",
   "description": "Robust configuration management system with web interface for ESP32 and ota support.",
   "repository": {

--- a/library.json
+++ b/library.json
@@ -56,8 +56,8 @@
     ]
   },
   "dependencies": [
-    "bblanchon/ArduinoJson@~7.4.1",
-    "esphome/ESPAsyncWebServer-esphome@~3.2.2",
+    "bblanchon/ArduinoJson@~7.4.3",
+    "esphome/ESPAsyncWebServer-esphome@~3.4.0",
     "esphome/AsyncTCP-esphome@2.1.4"
   ]
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,8 +28,8 @@ build_flags =
 test_build_src = yes
 
 lib_deps =
-	bblanchon/ArduinoJson@^7.4.1
-	esphome/ESPAsyncWebServer-esphome@^3.2.2
+	bblanchon/ArduinoJson@^7.4.3
+	esphome/ESPAsyncWebServer-esphome@^3.4.0
 	esphome/AsyncTCP-esphome@2.1.4
 
 

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -44,7 +44,7 @@ public:
 };
 #endif
 
-#define CONFIGMANAGER_VERSION "4.0.0" // Synced to library.json
+#define CONFIGMANAGER_VERSION "4.0.1" // Synced to library.json
 
 #if CM_ENABLE_THEMING && CM_ENABLE_STYLE_RULES
 inline constexpr char CM_DEFAULT_RUNTIME_STYLE_CSS[] PROGMEM = R"CSS(


### PR DESCRIPTION
Update PlatformIO library dependencies and apply the required patch version bump.

Changes:
- Update ArduinoJson from 7.4.1 to 7.4.3.
- Update ESPAsyncWebServer-esphome from 3.2.2 to 3.4.0.
- Keep AsyncTCP-esphome at 2.1.4 because no newer esphome package version was found.
- Bump ConfigurationsManager from 4.0.0 to 4.0.1.
- Keep SolarInverterLimiter firmware VERSION at 4.1.1 because it is owned by the independent example firmware.
- Clarify governance so independent example firmware/app versions are not bumped automatically for library dependency maintenance.

Validation:
- `pio run -e usb` in `examples\SolarInverterLimiter`: SUCCESS
- root `pio run -e usb`: SUCCESS

Risks:
- SolarInverterLimiter flash usage remains high at 98.8%.
- npm reports 2 moderate severity vulnerabilities during WebUI precompile; unrelated to this dependency update.