### PR TITLE
Refine governance rules for version and documentation flow

### DIFF
--- a/.github/agents.md
+++ b/.github/agents.md
@@ -131,6 +131,22 @@ support tooling used by the embedded project.
   exception.
 - Fast-forward integration to `main` is allowed only when the user explicitly
   requests fast-forward or `ff`.
+- Before preparing or merging changes into `main`, perform a documentation
+  impact check.
+- The documentation impact check must decide whether changed files or behavior
+  require documentation updates.
+- If documentation is affected, route the work through
+  `.github/agents/docs.agent.md` before integration.
+- If `docs/CHANGELOG.md` exists and the change is user-visible,
+  release-relevant, dependency-related, build-related, or version-related,
+  update it or explicitly justify why no changelog update is needed.
+- If documentation is not affected, report that documentation sync is not
+  required and why.
+- Do not invent documentation updates for purely internal or governance-only
+  changes unless governance documentation itself changed.
+- Governance-only changes do not require changelog entries unless this
+  repository intentionally starts tracking governance changes in the changelog.
+- Documentation-only changes do not require a version bump.
 - Read-only git commands may be run without asking:
   - `git status`
   - `git diff`

--- a/.github/agents.md
+++ b/.github/agents.md
@@ -199,6 +199,13 @@ support tooling used by the embedded project.
 - Bump library or project version declarations for dependency and build metadata
   changes. Do not automatically bump independent example firmware or app
   versions.
+- Treat the ConfigurationsManager package/library version as the main project
+  version.
+- Treat the WebUI package under `webui/` as part of the repository build
+  artifact, not as an independent example firmware or app.
+- When WebUI npm dependencies, WebUI build metadata, or WebUI package metadata
+  change, align the WebUI package version with the ConfigurationsManager
+  package/library version.
 - Bump an example firmware or app version only when that example itself is
   intentionally changed or released.
 - If the version source of truth is unclear, stop and report candidate files

--- a/.github/agents/docs.agent.md
+++ b/.github/agents/docs.agent.md
@@ -44,6 +44,16 @@ Project Documentation Expectations:
 - Keep references to PlatformIO commands aligned with `platformio.ini`.
 - Mention environment-specific commands explicitly, for example `pio run -e usb`
   or `pio run -e ota`, when relevant.
+- Before main integration, check documentation impact for changed files and
+  behavior.
+- If `docs/CHANGELOG.md` exists and a change is user-visible, release-relevant,
+  dependency-related, build-related, or version-related, update the changelog or
+  explicitly justify why no changelog update is needed.
+- Do not invent documentation updates for purely internal or governance-only
+  changes unless governance documentation itself changed.
+- Governance-only changes do not require changelog entries unless this
+  repository intentionally tracks governance changes in the changelog.
+- Documentation-only changes do not require a version bump.
 
 Reporting:
 

--- a/.github/agents/refactor.agent.md
+++ b/.github/agents/refactor.agent.md
@@ -56,6 +56,13 @@ Version Handling:
 - Bump library or project version declarations for dependency and build metadata
   changes. Do not automatically bump independent example firmware or app
   versions.
+- Treat the ConfigurationsManager package/library version as the main project
+  version.
+- Treat the WebUI package under `webui/` as part of the repository build
+  artifact, not as an independent example firmware or app.
+- When WebUI npm dependencies, WebUI build metadata, or WebUI package metadata
+  change, align the WebUI package version with the ConfigurationsManager
+  package/library version.
 - Bump an example firmware or app version only when that example itself is
   intentionally changed or released.
 - If the version source of truth is unclear, stop and report candidate files

--- a/.github/agents/workflow.agent.md
+++ b/.github/agents/workflow.agent.md
@@ -133,6 +133,23 @@ This agent must apply `.github/AGENTS.md`.
 - Docker or image builds are not required unless configured in this repository
   or explicitly in scope.
 
+## Documentation Impact Workflow
+
+- Before `workflow.toMain` prepares or merges changes into `main`, perform a
+  documentation impact check.
+- Check whether the changed files or behavior require updates to `README.md`,
+  `docs/`, release notes, or governance documentation.
+- If documentation is affected, route through `docs.agent.md` before merging.
+- If `docs/CHANGELOG.md` exists and the change is user-visible,
+  release-relevant, dependency-related, build-related, or version-related,
+  update it or explicitly justify why no changelog update is needed.
+- If documentation is not affected, report that documentation sync is not
+  required and why.
+- Do not invent documentation updates for purely internal changes.
+- Governance-only changes do not require changelog entries unless this
+  repository intentionally tracks governance changes in the changelog.
+- Documentation-only changes do not require a version bump.
+
 ## Version Bump Workflow
 
 - Dependency updates, PlatformIO configuration changes, library metadata
@@ -187,7 +204,8 @@ These names describe expected intent if the user invokes them:
   relevant validation, do not merge to `main`, do not update `release/*`, and do
   not push unless explicitly requested or covered by a named workflow.
 - `workflow.toMain`: get validated work onto `main` through the agreed pull
-  request workflow unless the user explicitly requested fast-forward or `ff`.
+  request workflow unless the user explicitly requested fast-forward or `ff`;
+  perform the documentation impact check before merging.
 - `workflow.cleanBranches`: delete only branches verified as integrated.
 - `workflow.end`: inspect repository state and report current branch, changed
   files, validation state, and blockers without claiming merge or fix success.

--- a/.github/agents/workflow.agent.md
+++ b/.github/agents/workflow.agent.md
@@ -151,6 +151,15 @@ This agent must apply `.github/AGENTS.md`.
 - Before changing versions, search for version declarations and report the
   candidate files found.
 - If multiple version declarations exist, report them before changing versions.
+- Treat the ConfigurationsManager package/library version as the main project
+  version.
+- Treat the WebUI package under `webui/` as part of the repository build
+  artifact, not as an independent example firmware or app.
+- When WebUI npm dependencies, WebUI build metadata, or WebUI package metadata
+  change, align the WebUI package version with the ConfigurationsManager
+  package/library version.
+- Bump an example firmware or app version only when that example itself is
+  intentionally changed or released.
 - If the version source of truth is unclear, stop and report candidate files
   instead of guessing.
 


### PR DESCRIPTION
## Summary
- clarify that the WebUI package version follows the ConfigurationsManager package/library version
- keep independent example firmware or app versions separate
- require a documentation impact check before workflow.toMain merges into main
- route through docs.agent.md when documentation or changelog updates are relevant
- state that governance-only changes do not require a changelog entry or version bump

## Validation
- git status --short: clean
- inspected the .github diff locally
- skipped PlatformIO build because only governance files changed and no .cpp/.h files were modified
- skipped version bump because governance-only changes do not require one by policy

## Documentation impact
- checked documentation impact before main integration
- no README or changelog update is required because the change only updates governance rules under .github