### PR TITLE
Update changelog for WebUI Vite update

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This changelog is a curated overview.
 
+## 4.0.2
+
+- WebUI npm dependencies updated; Vite upgraded to 8.0.13.
+- Added esbuild as an explicit devDependency for the Vite 8 build path.
+- WebUI build target changed to `esnext` for Vite 8 / Rolldown compatibility.
+- WebUI package version aligned with the ConfigurationsManager package/library version at 4.0.2.
+- Independent example firmware/app versions were not changed.
+- SolarInverterLimiter remains close to the flash limit after the update.
+- Older browser compatibility may be reduced because the WebUI no longer targets the previous legacy browser output.
+
 ## 4.0.0
 
 - Breaking release from the 3.2.x line (public API and behavior refactors across modules/examples).


### PR DESCRIPTION
## Summary
- add a changelog entry for the already integrated WebUI and Vite update
- document the WebUI npm dependency update, Vite 8.0.13, explicit esbuild devDependency, and the esnext build target
- record that the WebUI package version is aligned with ConfigurationsManager 4.0.2
- note that independent example firmware or app versions were not changed

## Validation
- documentation-only change
- skipped PlatformIO build because no .cpp or .h files changed
- skipped version bump because the change only updates docs/CHANGELOG.md

## Documentation impact
- this PR updates docs/CHANGELOG.md for an already integrated change
