### PR TITLE
Improve SolarInverterLimiter WiFi reconnect recovery

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This changelog is a curated overview.
 
+## 4.0.3
+
+- WiFi reconnect recovery now retries after stalled ESP32 WiFi idle/scan states
+  instead of waiting indefinitely.
+- SolarInverterLimiter firmware version bumped to 4.1.2 for the runtime WiFi
+  recovery behavior change.
+
 ## 4.0.2
 
 - WebUI npm dependencies updated; Vite upgraded to 8.0.13.

--- a/examples/SolarInverterLimiter/src/main.cpp
+++ b/examples/SolarInverterLimiter/src/main.cpp
@@ -58,7 +58,7 @@
 #endif
 
 #ifndef VERSION
-#define VERSION "4.1.1"
+#define VERSION "4.1.2"
 #endif
 
 enum class NegativePriceSettingPreference : uint8_t

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32 Configuration Manager",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "keywords": "esp32, configuration, wifi, web-server, ota, iot, automation",
   "description": "Robust configuration management system with web interface for ESP32 and ota support.",
   "repository": {

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -44,7 +44,7 @@ public:
 };
 #endif
 
-#define CONFIGMANAGER_VERSION "4.0.2" // Synced to library.json
+#define CONFIGMANAGER_VERSION "4.0.3" // Synced to library.json
 
 #if CM_ENABLE_THEMING && CM_ENABLE_STYLE_RULES
 inline constexpr char CM_DEFAULT_RUNTIME_STYLE_CSS[] PROGMEM = R"CSS(

--- a/src/wifi/WiFiManager.cpp
+++ b/src/wifi/WiFiManager.cpp
@@ -504,22 +504,28 @@ void ConfigManagerWiFi::handleReconnection() {
   if (WiFi.getMode() == WIFI_AP) return; // Don't reconnect in AP mode
   if (stackResetInProgress || roamingReconnectPending) return;
 
+  unsigned long now = millis();
+  const unsigned long elapsedSinceAttempt = now - lastReconnectAttempt;
+
   // Avoid reconnect storms while the WiFi stack is already busy.
   // Some ESP32 Arduino stacks report WL_IDLE_STATUS during an ongoing connect and
   // WL_SCAN_COMPLETED transiently during scans.
   const int wifiStatus = WiFi.status();
-  if (wifiStatus == WL_IDLE_STATUS || wifiStatus == WL_SCAN_COMPLETED) {
+  const bool stackBusy = (wifiStatus == WL_IDLE_STATUS || wifiStatus == WL_SCAN_COMPLETED);
+  if (stackBusy && elapsedSinceAttempt < reconnectInterval) {
     return;
   }
 
-  unsigned long now = millis();
-
   // Non-blocking reconnection attempt
-  if (now - lastReconnectAttempt >= reconnectInterval) {
+  if (elapsedSinceAttempt >= reconnectInterval) {
     lastReconnectAttempt = now;
     if (currentState != WIFI_STATE_RECONNECTING) {
       transitionToState(WIFI_STATE_RECONNECTING);
     }
+    WIFI_LOG("Reconnect attempt %u after status %d (%s)",
+             static_cast<unsigned int>(connectAttempts) + 1U,
+             wifiStatus,
+             getWiFiStatusString(wifiStatus).c_str());
     attemptConnect();
   }
 }


### PR DESCRIPTION
## Summary\n- improve WiFi reconnect recovery in ConfigManagerWiFi for SolarInverterLimiter\n- bump ConfigurationsManager version from 4.0.2 to 4.0.3\n- bump SolarInverterLimiter firmware version from 4.1.1 to 4.1.2\n- update docs/CHANGELOG.md\n- keep the WebUI package version unchanged\n\n## Validation\n- `pio run -e usb` in `examples/SolarInverterLimiter`: SUCCESS\n  - RAM: 62792 / 327680 bytes, 19.2%\n  - Flash: 1295425 / 1310720 bytes, 98.8%\n- root `pio run -e usb`: SUCCESS\n  - RAM: 27452 / 327680 bytes, 8.4%\n  - Flash: 485457 / 1310720 bytes, 37.0%\n\n## Documentation impact\n- changelog updated\n- no further documentation updates were required for this change\n\n## Remaining blocker\n- real-device verification is still required on the actual SolarInverterLimiter under weak WiFi conditions before this can be considered fixed\n\n## Known risks\n- SolarInverterLimiter remains close to the flash limit at 98.8%\n- real weak-WiFi recovery behavior still needs device verification\n- npm audit still reports 1 moderate severity vulnerability unrelated to this fix\n