### PR TITLE
Update BoilerSaver example

### DIFF
--- a/examples/BoilerSaver/Wokwi/diagram.json
+++ b/examples/BoilerSaver/Wokwi/diagram.json
@@ -1,0 +1,158 @@
+{
+  "version": 1,
+  "author": "Vitaly Ruhl",
+  "editor": "wokwi",
+  "parts": [
+    { "type": "wokwi-esp32-devkit-v1", "id": "esp1", "top": 4.7, "left": -33.8, "attrs": {} },
+    { "type": "wokwi-relay-module", "id": "relay1", "top": 307.4, "left": 201.6, "attrs": {} },
+    {
+      "type": "wokwi-text",
+      "id": "text2",
+      "top": 374.4,
+      "left": 163.2,
+      "attrs": { "text": "Relay (OFF=NC active)" }
+    },
+    {
+      "type": "wokwi-pushbutton",
+      "id": "btn1",
+      "top": 217.4,
+      "left": -230.4,
+      "attrs": { "color": "green", "xray": "1" }
+    },
+    {
+      "type": "wokwi-text",
+      "id": "text4",
+      "top": 220.8,
+      "left": -307.2,
+      "attrs": { "text": "AP-Mode" }
+    },
+    {
+      "type": "wokwi-pushbutton",
+      "id": "btn3",
+      "top": 92.6,
+      "left": -230.4,
+      "attrs": { "color": "green", "xray": "1" }
+    },
+    {
+      "type": "wokwi-text",
+      "id": "text5",
+      "top": 105.6,
+      "left": -345.6,
+      "attrs": { "text": "Reset-to-default" }
+    },
+    {
+      "type": "wokwi-resistor",
+      "id": "r2",
+      "top": 360,
+      "left": 421.85,
+      "rotate": 90,
+      "attrs": { "value": "2400" }
+    },
+    {
+      "type": "wokwi-text",
+      "id": "text9",
+      "top": 220.8,
+      "left": 297.6,
+      "attrs": { "text": "(I2C) GM009605" }
+    },
+    {
+      "type": "wokwi-pushbutton",
+      "id": "btn2",
+      "top": 6.2,
+      "left": -240,
+      "attrs": { "color": "green", "xray": "1" }
+    },
+    {
+      "type": "wokwi-text",
+      "id": "text3",
+      "top": 19.2,
+      "left": -384,
+      "attrs": { "text": "Will Shower Button" }
+    },
+    { "type": "wokwi-potentiometer", "id": "pot1", "top": 248.3, "left": 527.8, "attrs": {} },
+    {
+      "type": "wokwi-text",
+      "id": "text6",
+      "top": 220.8,
+      "left": 518.4,
+      "attrs": { "text": "202 = 2 kOhm" }
+    },
+    {
+      "type": "board-ssd1306",
+      "id": "oled1",
+      "top": 127.94,
+      "left": 297.83,
+      "attrs": { "i2cAddress": "0x3c" }
+    },
+    {
+      "type": "wokwi-resistor",
+      "id": "r1",
+      "top": 388.8,
+      "left": 786.65,
+      "rotate": 90,
+      "attrs": { "value": "1000" }
+    },
+    {
+      "type": "wokwi-text",
+      "id": "text7",
+      "top": 374.4,
+      "left": 835.2,
+      "attrs": { "text": "Heater-NTC" }
+    },
+    {
+      "type": "wokwi-text",
+      "id": "text8",
+      "top": 297.6,
+      "left": 614.4,
+      "attrs": { "text": "target: ~1.5 kOhm (Relay OFF)" }
+    },
+    { "type": "wokwi-ds18b20", "id": "ds1", "top": -183.53, "left": -111.12, "attrs": {} },
+    {
+      "type": "wokwi-resistor",
+      "id": "r3",
+      "top": -33.6,
+      "left": -134.95,
+      "attrs": { "value": "4700" }
+    },
+    {
+      "type": "wokwi-text",
+      "id": "text10",
+      "top": -201.6,
+      "left": -211.2,
+      "attrs": { "text": "DS18B20 (GPIO26, 4.7k pull-up)" }
+    },
+    {
+      "type": "wokwi-text",
+      "id": "text1",
+      "top": -220.8,
+      "left": -211.2,
+      "attrs": { "text": "Real Temperature measurment" }
+    }
+  ],
+  "connections": [
+    [ "relay1:VCC", "esp1:VIN", "red", [ "h-288", "v-134.4" ] ],
+    [ "relay1:GND", "esp1:GND.1", "black", [ "h-19.2", "v-154", "v-28.7" ] ],
+    [ "relay1:IN", "esp1:D23", "yellow", [ "h-86.4", "v-134.6", "v-182.5" ] ],
+    [ "btn1:1.r", "esp1:D13", "green", [ "v0" ] ],
+    [ "esp1:GND.2", "btn1:2.r", "black", [ "h-96", "v66.9" ] ],
+    [ "btn3:2.r", "esp1:GND.2", "black", [ "h0.2", "v57.9" ] ],
+    [ "btn3:1.r", "esp1:D14", "green", [ "h57.8", "v47.9" ] ],
+    [ "btn3:2.r", "btn2:2.r", "black", [ "h9.8", "v-86.4" ] ],
+    [ "btn2:1.r", "esp1:D33", "green", [ "h96.2", "v96" ] ],
+    [ "r2:1", "pot1:GND", "green", [ "v0" ] ],
+    [ "r2:2", "pot1:SIG", "green", [ "v18", "h115.6" ] ],
+    [ "esp1:D22", "oled1:SCL", "magenta", [ "h0" ] ],
+    [ "esp1:D21", "oled1:SDA", "purple", [ "h0" ] ],
+    [ "esp1:3V3", "oled1:VCC", "red", [ "h220.5", "v-86.4", "h76.65" ] ],
+    [ "esp1:GND.1", "oled1:GND", "black", [ "h191.7", "v-67.3", "h76.8" ] ],
+    [ "pot1:VCC", "r1:1", "orange", [ "v19.2", "h230.15" ] ],
+    [ "r2:1", "relay1:NC", "green", [ "v-19.2", "h-48", "v10.8" ] ],
+    [ "relay1:COM", "r1:2", "gold", [ "h49.2", "v104.2", "h326.4", "h124.8" ] ],
+    [ "esp1:3V3", "ds1:VCC", "red", [ "h28.5", "v-297.6" ] ],
+    [ "r3:1", "ds1:DQ", "gold", [ "v-9.6", "h-48" ] ],
+    [ "r3:2", "ds1:VCC", "red", [ "v-19.2", "h-48" ] ],
+    [ "btn2:2.r", "ds1:GND", "black", [ "h19.4", "v-115", "h48" ] ],
+    [ "r3:1", "esp1:D26", "gold", [ "h-9.05", "v123.95", "h57.6", "v9.7" ] ]
+  ],
+  "dependencies": {}
+}

--- a/examples/BoilerSaver/Wokwi/wokwi.toml
+++ b/examples/BoilerSaver/Wokwi/wokwi.toml
@@ -1,0 +1,7 @@
+[wokwi]
+version = 1
+firmware = '.pio/build/sd/firmware.elf'
+elf = '.pio/build/sd/firmware.elf'
+
+gdbServerPort=3333
+rfc2217ServerPort = 4000

--- a/examples/BoilerSaver/platformio.ini
+++ b/examples/BoilerSaver/platformio.ini
@@ -12,9 +12,6 @@
 [platformio]
 description = esp32 c++ V17 Project to save gas on heatup only when needed with web configuration
 
-build_dir = ${sysenv.HOME}/.pio/CM/ex/BoilerSaver
-libdeps_dir = ${sysenv.HOME}/.pio/CM/ex/BoilerSaver/libdeps
-
 [env:usb]
 platform = espressif32
 board = nodemcu-32s
@@ -32,19 +29,21 @@ build_flags =
 	-DCM_ENABLE_LOGGING=0
 	-DCM_ENABLE_VERBOSE_LOGGING=0
 	-DCM_LOGGING_LEVEL=CM_LOG_LEVEL_WARN
-extra_scripts =
-	pre:../../tools/pio_force_local_lib_refresh.py
-	pre:../../tools/preCompile_script.py
 lib_deps =
-	bblanchon/ArduinoJson@^7.4.1
+	bblanchon/ArduinoJson@^7.4.3
 	esphome/ESPAsyncWebServer-esphome@^3.2.2
 	esphome/AsyncTCP-esphome@2.1.4
 	knolleary/PubSubClient@^2.8
 	paulstoffregen/OneWire@^2.3.7
-	milesburton/DallasTemperature@^3.11.0
-	adafruit/Adafruit GFX Library@^1.12.4
+	milesburton/DallasTemperature@^4.0.6
+	adafruit/Adafruit GFX Library@^1.12.6
 	adafruit/Adafruit SSD1306@^2.5.13
-	../..
+	vitaly.ruhl/ESP32 Configuration Manager@^4.0.3
+	; C:\Daten\_Codding\ESP32\ConfigurationsManager
+test_ignore = src/main.cpp
+extra_scripts =
+	pre:./tools/precompile_wrapper.py
+
 
 [env:ota]
 platform = espressif32
@@ -62,23 +61,26 @@ build_flags =
 	-DCM_ENABLE_LOGGING=0
 	-DCM_ENABLE_VERBOSE_LOGGING=0
 	-DCM_LOGGING_LEVEL=CM_LOG_LEVEL_WARN
-lib_deps =cd
-	bblanchon/ArduinoJson@^7.4.1
+lib_deps =
+	bblanchon/ArduinoJson@^7.4.3
 	esphome/ESPAsyncWebServer-esphome@^3.2.2
 	esphome/AsyncTCP-esphome@2.1.4
 	knolleary/PubSubClient@^2.8
-	adafruit/Adafruit SSD1306@^2.5.13
-	adafruit/Adafruit GFX Library@^1.12.4
-	adafruit/Adafruit BusIO@^1.17.4
 	paulstoffregen/OneWire@^2.3.7
-	milesburton/DallasTemperature@^3.11.0
-	../..
+	milesburton/DallasTemperature@^4.0.6
+	adafruit/Adafruit GFX Library@^1.12.6
+	adafruit/Adafruit SSD1306@^2.5.13
+	vitaly.ruhl/ESP32 Configuration Manager@^4.0.3
+	; C:\Daten\_Codding\ESP32\ConfigurationsManager
+test_ignore = src/main.cpp
 extra_scripts =
-	pre:../../tools/pio_force_local_lib_refresh.py
-	pre:../../tools/preCompile_script.py
+	pre:./tools/precompile_wrapper.py
 
 upload_protocol = espota
-upload_port = 192.168.2.126
-; upload_port = 192.168.2.130
-; upload_flags = --auth=173f58
-; upload_flags = --auth=ota1234
+upload_port = 192.168.2.130
+;upload_flags = --auth=ota1234 -t 120 -c 512
+upload_flags =
+    -a
+    ota1234
+    -t
+    600

--- a/examples/BoilerSaver/src/main.cpp
+++ b/examples/BoilerSaver/src/main.cpp
@@ -63,8 +63,10 @@ static void setBoilerState(bool on);
 static bool getBoilerState();
 static void cb_readTempSensor();
 static void setupTempSensor();
+static void applyTempReadInterval();
 static void handleShowerRequest(bool requested);
 static void setupNetworkDefaults();
+static void applyWiFiMacPriority();
 
 //--------------------------------------------------------------------------------------------------------------
 
@@ -77,7 +79,7 @@ static const char GLOBAL_THEME_OVERRIDE[] PROGMEM = R"CSS(
 
 // static const char SETTINGS_PASSWORD[] = "";
 
-// Global pulse helper: built-in LED
+// Built-in LED pulse helper for WiFi status patterns.
 static cm::helpers::PulseOutput buildinLED(LED_BUILTIN, cm::helpers::PulseOutput::ActiveLevel::ActiveHigh);
 
 static cm::LoggingManager &lmg = cm::LoggingManager::instance();
@@ -193,9 +195,7 @@ void setup()
     ShowDisplay();
     setupTempSensor();
     
-#if defined(WIFI_FILTER_MAC_PRIORITY)
-    ConfigManager.setAccessPointMacPriority(WIFI_FILTER_MAC_PRIORITY);
-#endif
+    applyWiFiMacPriority();
     ConfigManager.startWebServer();
 
     lmg.log("System setup completed.");
@@ -400,7 +400,6 @@ void UpdateBoilerAlarmState()
 
     if (globalAlarmState != previousState)
     {
-        // todo -a add a new LL:state:Alarm for alarms
         lmg.log(LL::Error, "Temperature %.1f°C -> %s",
                 temperature, globalAlarmState ? "HEATER ON" : "HEATER OFF");
         handeleBoilerState(true); // Force boiler if the temperature is too low
@@ -510,7 +509,7 @@ static void cb_readTempSensor()
     lmg.scopedTag("TEMP");
     if (!ds18)
     {
-        lmg.log(LL::Warn, "DS18B20 sensor not initialized");
+        lmg.log(LL::Error, "DS18B20 sensor not initialized");
         return;
     }
     ds18->requestTemperatures();
@@ -527,7 +526,7 @@ static void cb_readTempSensor()
             sensorFaultState = true;
             lmg.log(LL::Error, "SENSOR FAULT detected! Reading: %.2f°C", t);
         }
-        lmg.log(LL::Warn, "Invalid temperature reading: %.2f°C (sensor fault)", t);
+        lmg.log(LL::Error, "Invalid temperature reading: %.2f°C (sensor fault)", t);
         // Try to check if sensor is still present
         uint8_t deviceCount = ds18->getDeviceCount();
         lmg.log(LL::Debug, "Devices still found: %d", deviceCount);
@@ -594,12 +593,24 @@ static void setupTempSensor()
         lmg.log(LL::Info, "Resolution set to 12-bit");
     }
 
+    tempSensorSettings.readInterval->setCallback([](int)
+                                                 { applyTempReadInterval(); });
+    applyTempReadInterval();
+        lmg.log(LL::Debug, "DS18B20 initialized on GPIO %d, offset %.2f°C",
+            pin, tempSensorSettings.corrOffset->get());
+}
+
+static void applyTempReadInterval()
+{
     float intervalSec = (float)tempSensorSettings.readInterval->get();
     if (intervalSec < 1.0f)
-        intervalSec = 30.0f;
+    {
+        intervalSec = 10.0f;
+    }
+
+    TempReadTicker.detach();
     TempReadTicker.attach(intervalSec, cb_readTempSensor);
-    lmg.log(LL::Debug, "DS18B20 initialized on GPIO %d, interval %.1fs, offset %.2f°C",
-            pin, intervalSec, tempSensorSettings.corrOffset->get());
+    lmg.log(LL::Debug, "Temp read interval set: %.1fs", intervalSec);
 }
 
 //----------------------------------------
@@ -638,7 +649,7 @@ static void registerIOBindings()
 
     ioManager.addDigitalInput(IO_AP_ID, "AP Mode Button", 13, true, true, false, true);
 
-    ioManager.addDigitalInput(IO_SHOWER_ID, "Shower Request Button", 33, true, true, false, true);
+    ioManager.addDigitalInput(IO_SHOWER_ID, "Shower Request Button", 19, true, true, false, true);
 
     ioManager.addDigitalInputToSettingsGroup(IO_SHOWER_ID, "I/O", "Shower HW-Btn", "Shower HW-Btn", 100);
     ioManager.addDigitalInputToLive(IO_SHOWER_ID, 100, "Boiler", "Boiler", "Boiler", "Shower HW-Btn", false);
@@ -683,6 +694,13 @@ static void registerIOBindings()
         cm::IOManager::DigitalInputEventCallbacks{
             .onPress = []()
             {
+                if (!displayActive)
+                {
+                    lmg.log(LL::Debug, "[MAIN] Shower button pressed while display OFF -> wake display only");
+                    ShowDisplay();
+                    return;
+                }
+
                 const bool newState = !willShowerRequested;
                 lmg.log(LL::Debug, "[MAIN] Shower button pressed -> toggling shower request to %s",
                         newState ? "ON" : "OFF");
@@ -862,8 +880,6 @@ static void publishMqttState(bool retained)
         }
     }
 
-    // TODO: add into IO-Manager Blinker support
-    buildinLED.setPulseRepeat(/*count*/ 1, /*periodMs*/ 100, /*gapMs*/ 1500);
 }
 
 static void publishMqttStateIfNeeded()
@@ -1228,6 +1244,15 @@ void ShowDisplay()
 void ShowDisplayOff()
 {
     displayTicker.detach();                      // Stop the ticker to prevent multiple calls
+
+    if (willShowerRequested)
+    {
+        display.ssd1306_command(SSD1306_DISPLAYON);
+        displayActive = true;
+        displayTicker.attach(displaySettings.onTimeSec->get(), ShowDisplayOff);
+        return;
+    }
+
     display.ssd1306_command(SSD1306_DISPLAYOFF); // Turn off the display
     // display.fillRect(0, 0, 128, 24, BLACK); // Clear the previous message area
 
@@ -1264,8 +1289,7 @@ void updateStatusLED()
         buildinLED.setPulseRepeat(/*count*/ 1, /*periodMs*/ 200, /*gapMs*/ 0);
         break;
     case 2: // Connected: 60ms ON heartbeat every 2s -> 120ms pulse + 1880ms gap
-        // mooved into send mqtt function to have heartbeat with mqtt messages
-        //  buildinLED.setPulseRepeat(/*count*/ 1, /*periodMs*/ 120, /*gapMs*/ 1880);
+        buildinLED.setPulseRepeat(/*count*/ 1, /*periodMs*/ 100, /*gapMs*/ 1500);
         break;
     case 3: // Connecting: double blink every ~1s -> two 200ms pulses + 600ms gap
         buildinLED.setPulseRepeat(/*count*/ 3, /*periodMs*/ 200, /*gapMs*/ 600);
@@ -1274,9 +1298,6 @@ void updateStatusLED()
 }
 
 //----------------------------------------
-// WIFI MANAGER CALLBACK FUNCTIONS
-//----------------------------------------
-
 void onWiFiConnected()
 {
     lmg.scopedTag("MAIN/WIFI");
@@ -1341,6 +1362,14 @@ static void handleShowerRequest(bool v)
 
 static void setupNetworkDefaults()
 {
+#if CM_HAS_WIFI_SECRETS && defined(WIFI_FILTER_MAC_PRIORITY)
+    if (wifiUiSettings.apMacPriority != nullptr && wifiUiSettings.apMacPriority->get().isEmpty())
+    {
+        wifiUiSettings.apMacPriority->set(String(WIFI_FILTER_MAC_PRIORITY));
+        ConfigManager.saveAll();
+    }
+#endif
+
     if (wifiSettings.wifiSsid.get().isEmpty())
     {
 #if CM_HAS_WIFI_SECRETS
@@ -1407,4 +1436,21 @@ static void setupNetworkDefaults()
     {
         systemSettings.otaPassword.save(OTA_PASSWORD);
     }
+}
+
+static void applyWiFiMacPriority()
+{
+    if (wifiUiSettings.apMacPriority == nullptr)
+    {
+        return;
+    }
+
+    const String preferredApMac = wifiUiSettings.apMacPriority->get();
+    if (preferredApMac.isEmpty())
+    {
+        return;
+    }
+
+    ConfigManager.setAccessPointMacPriority(preferredApMac);
+    lmg.log(LL::Debug, "WiFi AP MAC priority active: %s", preferredApMac.c_str());
 }

--- a/examples/BoilerSaver/src/settings.cpp
+++ b/examples/BoilerSaver/src/settings.cpp
@@ -5,6 +5,7 @@ I2CSettings i2cSettings;
 DisplaySettings displaySettings;
 BoilerSettings boilerSettings;
 TempSensorSettings tempSensorSettings;
+WiFiUiSettings wifiUiSettings;
 
 // Function to register all settings with ConfigManager
 // This solves the static initialization order problem
@@ -13,4 +14,5 @@ void initializeAllSettings() {
     boilerSettings.create();
     displaySettings.create();
     tempSensorSettings.create();
+    wifiUiSettings.create();
 }

--- a/examples/BoilerSaver/src/settings.h
+++ b/examples/BoilerSaver/src/settings.h
@@ -7,8 +7,8 @@
 
 #include "ConfigManager.h"
 
-#define APP_VERSION "4.0.0"
-#define VERSION_DATE "05.11.2025"
+#define APP_VERSION "4.0.3"
+#define VERSION_DATE "17.05.2026"
 #ifndef APP_NAME
 #define APP_NAME "Boiler-Saver"
 #endif
@@ -64,22 +64,22 @@ struct BoilerSettings {
         onThreshold = &ConfigManager.addSettingFloat("BoI_OnT")
                           .name("Alarm Under Temperature")
                           .category("Boiler")
-                          .defaultValue(55.0f)
+                          .defaultValue(60.0f)
                           .build();
         offThreshold = &ConfigManager.addSettingFloat("BoI_OffT")
                            .name("You can shower now temperature")
                            .category("Boiler")
-                           .defaultValue(80.0f)
+                           .defaultValue(78.0f)
                            .build();
         boilerTimeMin = &ConfigManager.addSettingInt("BoI_Time")
                              .name("Boiler Max Heating Time (min)")
                              .category("Boiler")
-                             .defaultValue(90)
+                             .defaultValue(120)
                              .build();
         stopTimerOnTarget = &ConfigManager.addSettingBool("BoI_StopOnT")
                                  .name("Stop timer when target reached")
                                  .category("Boiler")
-                                 .defaultValue(true)
+                                 .defaultValue(false)
                                  .build();
         onlyOncePerPeriod = &ConfigManager.addSettingBool("YSNOnce")
                                  .name("Notify once per period")
@@ -118,17 +118,30 @@ struct TempSensorSettings {
         gpioPin = &ConfigManager.addSettingInt("TsPin")
                        .name("GPIO Pin")
                        .category("Temp Sensor")
-                       .defaultValue(18)
+                       .defaultValue(26)
                        .build();
         corrOffset = &ConfigManager.addSettingFloat("TsOfs")
                           .name("Correction Offset")
                           .category("Temp Sensor")
-                          .defaultValue(0.0f)
+                          .defaultValue(15.0f)
                           .build();
         readInterval = &ConfigManager.addSettingInt("TsInt")
                              .name("Read Interval (s)")
                              .category("Temp Sensor")
-                             .defaultValue(30)
+                             .defaultValue(10)
+                             .build();
+    }
+};
+
+struct WiFiUiSettings {
+    Config<String> *apMacPriority = nullptr;
+
+    void create()
+    {
+        apMacPriority = &ConfigManager.addSettingString("WiFiMacPr")
+                             .name("Preferred AP MAC (optional)")
+                             .category("WiFi")
+                             .defaultValue(String(""))
                              .build();
     }
 };
@@ -137,6 +150,7 @@ extern I2CSettings i2cSettings;
 extern DisplaySettings displaySettings;
 extern TempSensorSettings tempSensorSettings;
 extern BoilerSettings boilerSettings;
+extern WiFiUiSettings wifiUiSettings;
 
 // Function to register all settings with ConfigManager
 // This must be called after ConfigManager is properly initialized

--- a/examples/BoilerSaver/tools/precompile_wrapper.py
+++ b/examples/BoilerSaver/tools/precompile_wrapper.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+Wrapper script to call the precompile script from the ESP32 Configuration Manager library.
+This ensures the script runs during PlatformIO build process.
+"""
+
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+# Try to access PlatformIO/SCons build environment 
+try:
+    from SCons.Script import Import  # type: ignore
+    Import('env')  # provides "env" from PlatformIO
+    print("[precompile_wrapper] Starting ESP32 Configuration Manager precompile...")
+    SCONS_AVAILABLE = True
+except Exception:
+    env = None
+    print("[precompile_wrapper] SCons environment not available, running in standalone mode")
+    SCONS_AVAILABLE = False
+
+def _get_define_from_scons(name: str, default: int) -> int:
+    """Read -D defines from PlatformIO/SCons env (CPPDEFINES)."""
+    if not SCONS_AVAILABLE or env is None:
+        return default
+    try:
+        defines = env.get('CPPDEFINES', [])
+        for d in defines:
+            if isinstance(d, tuple) and len(d) == 2:
+                k, v = d
+                if k == name:
+                    try:
+                        return int(v)
+                    except Exception:
+                        return 1 if str(v).lower() in ('1', 'true', 'yes', 'on') else 0
+            elif isinstance(d, str) and d == name:
+                return 1
+    except Exception:
+        return default
+    return default
+
+
+LOGGING_ENABLED = _get_define_from_scons('CM_ENABLE_LOGGING', 1) == 1
+VERBOSE_LOGGING_ENABLED = _get_define_from_scons('CM_ENABLE_VERBOSE_LOGGING', 0) == 1
+
+
+def log(message):
+    if not LOGGING_ENABLED:
+        return
+    print(message)
+    sys.stdout.flush()
+
+
+def vlog(message):
+    if not VERBOSE_LOGGING_ENABLED:
+        return
+    log(message)
+
+def main():
+    if not SCONS_AVAILABLE:
+        print("[precompile_wrapper] Starting precompile wrapper...")
+    
+    # Get the project directory
+    project_dir = Path(os.getcwd())
+    
+    if not SCONS_AVAILABLE:
+        print(f"[precompile_wrapper] Project directory: {project_dir}")
+    
+    # Determine active PlatformIO environment (fallback to 'usb' if undetermined)
+    try:
+        active_env = (env.get('PIOENV') if SCONS_AVAILABLE else None) or os.environ.get('PIOENV') or os.environ.get('PLATFORMIO_ENV') or 'usb'
+    except Exception:
+        active_env = os.environ.get('PIOENV') or os.environ.get('PLATFORMIO_ENV') or 'usb'
+
+    # Find the ESP32 Configuration Manager library directory
+    lib_path = project_dir / ".pio" / "libdeps" / active_env / "ESP32 Configuration Manager"
+    
+    if not lib_path.exists():
+        print(f"[precompile_wrapper] Library not found at: {lib_path}")
+        print("[precompile_wrapper] Skipping precompile step...")
+        return
+    
+    # Path to the actual precompile script
+    precompile_script = lib_path / "tools" / "preCompile_script.py"
+    
+    if not precompile_script.exists():
+        print(f"[precompile_wrapper] Precompile script not found at: {precompile_script}")
+        print("[precompile_wrapper] Skipping precompile step...")
+        return
+    
+    print(f"[precompile_wrapper] Running ESP32 Configuration Manager precompile script for env '{active_env}'...")
+    print(f"[precompile_wrapper] Library path: {lib_path}")
+    print(f"[precompile_wrapper] Script path: {precompile_script}")
+    
+    # Run the library script from the library directory (it expects its own relative paths)
+    # but propagate PlatformIO build flags explicitly so it can enable features correctly.
+    original_cwd = os.getcwd()
+    try:
+        # Set environment variables that the script might need
+        env_vars = os.environ.copy()
+        env_vars['PIOENV'] = active_env
+        env_vars['PLATFORMIO_ENV'] = active_env
+        env_vars['PROJECT_DIR'] = str(project_dir)
+        # Ensure devDependencies (vite, @vitejs/plugin-vue) are installed
+        env_vars['NODE_ENV'] = 'development'
+        print(f"[precompile_wrapper] Original CWD: {original_cwd}")
+        
+        def _collect_local_lib_paths(ini_path: Path):
+            """Return a list of candidate local library paths which exist on disk.
+            Sources:
+              - Environment variables: CM_LOCAL_LIB, ESP32_CONFIG_MANAGER_LOCAL, ESP32_CONFIG_LIB_PATH
+              - Absolute paths present (even commented) under lib_deps section
+              - Common defaults near this workspace
+            """
+            paths = []
+
+            # 1) Environment variables
+            for var in ('CM_LOCAL_LIB', 'ESP32_CONFIG_MANAGER_LOCAL', 'ESP32_CONFIG_LIB_PATH'):
+                v = os.environ.get(var)
+                if v:
+                    p = Path(v)
+                    if p.exists() and p.is_dir():
+                        paths.append(p)
+
+            # 2) Absolute paths present in platformio.ini (tolerate commented lines)
+            if ini_path.exists():
+                lines = ini_path.read_text(encoding='utf-8', errors='ignore').splitlines()
+                capture = False
+                for line in lines:
+                    raw = line.rstrip('\n')
+                    s = raw.strip()
+                    if s.startswith('lib_deps'):
+                        capture = True
+                        continue
+                    if capture:
+                        # Stop on next config key
+                        if s and not raw.startswith(('	', ' ', ';', '#')) and '=' in raw:
+                            capture = False
+                        # Collect even commented absolute paths for convenience
+                        cand = s.lstrip(';').strip()
+                        if cand and (':' in cand or cand.startswith('\\')):
+                            p = Path(cand)
+                            if p.exists() and p.is_dir():
+                                paths.append(p)
+
+            # 3) Common defaults (user-specific, but helpful)
+            default_candidates = [
+                Path('C:/Daten/_Codding/ESP32/ConfigurationsManager'),
+                project_dir.parent / 'ConfigurationsManager',
+            ]
+            for p in default_candidates:
+                if p.exists() and p.is_dir():
+                    paths.append(p)
+
+            # De-duplicate preserving order
+            seen = set()
+            uniq = []
+            for p in paths:
+                if str(p) not in seen:
+                    seen.add(str(p))
+                    uniq.append(p)
+            return uniq
+
+        def _ensure_webui_sources(libdir: Path) -> bool:
+            """Ensure libdir/webui sources are present and up-to-date.
+            If a local library/project copy exists, prefer syncing it into libdeps so the build uses the project's WebUI.
+            """
+            wdir = libdir / 'webui'
+            idx = wdir / 'index.html'
+            # Always try to sync from a local source if available, even when files exist already.
+            # This lets developers customize webui in their workspace and have it take effect at build time.
+            local_paths = _collect_local_lib_paths(project_dir / 'platformio.ini')
+            for lp in local_paths:
+                src_wui = lp / 'webui'
+                if (src_wui / 'index.html').exists():
+                    print(f"[precompile_wrapper] Syncing webui sources from local project: {src_wui} -> {wdir}")
+                    # copy selected items (avoid node_modules heavy copy when possible)
+                    import shutil
+                    wdir.mkdir(parents=True, exist_ok=True)
+                    # items to copy
+                    for name in ['index.html', 'src', 'public', 'vite.config.mjs', 'package.json', 'package-lock.json', 'db.json', 'db.live.json', 'runtime_meta_min.json', 'logo.svg']:
+                        s = src_wui / name
+                        d = wdir / name
+                        try:
+                            if s.is_dir():
+                                if d.exists():
+                                    shutil.rmtree(d)
+                                shutil.copytree(s, d)
+                            elif s.is_file():
+                                shutil.copy2(s, d)
+                        except Exception as ce:
+                            print(f"[precompile_wrapper] Warning: failed copying {s} -> {d}: {ce}")
+                    # Ensure vite CLI is available. If npm install later still fails because vite bin missing,
+                    # proactively copy node_modules from local lib as a fallback.
+                    src_nm = src_wui / 'node_modules'
+                    dst_nm = wdir / 'node_modules'
+                    try:
+                        need_nm_copy = False
+                        if not dst_nm.exists():
+                            need_nm_copy = True
+                        else:
+                            if not (dst_nm / 'vite' / 'bin' / 'vite.js').exists():
+                                need_nm_copy = True
+                        if need_nm_copy and src_nm.exists():
+                            print("[precompile_wrapper] Hydrating node_modules from local library (vite CLI)")
+                            if dst_nm.exists():
+                                shutil.rmtree(dst_nm)
+                            shutil.copytree(src_nm, dst_nm)
+                    except Exception as ce:
+                        print(f"[precompile_wrapper] Note: could not copy node_modules: {ce}")
+                    # After syncing, ensure index.html exists in destination
+                    return (wdir / 'index.html').exists()
+
+            # If no local sources available, ensure at least the packaged webui exists
+            if idx.exists():
+                return True
+            print("[precompile_wrapper] WARNING: webui sources not found; skipping Vue rebuild and keeping packaged header.")
+            return False
+
+        def _sync_cpp_sources(libdir: Path) -> bool:
+            """Sync C++ sources from a local project/library into libdeps copy.
+            This ensures the backend (endpoints, decrypt logic) matches the local workspace when testing in another project.
+            """
+            try:
+                local_paths = _collect_local_lib_paths(project_dir / 'platformio.ini')
+                for lp in local_paths:
+                    # Expect a library-like layout at lp (this workspace): src/ ...
+                    src_root = lp / 'src'
+                    if src_root.exists() and src_root.is_dir():
+                        import shutil
+                        dst_root = libdir / 'src'
+                        print(f"[precompile_wrapper] Syncing C++ sources from local project: {src_root} -> {dst_root}")
+                        # Replace destination src completely to avoid stale files
+                        if dst_root.exists():
+                            try:
+                                shutil.rmtree(dst_root)
+                            except Exception as rexc:
+                                print(f"[precompile_wrapper] Warning: failed to remove old src: {rexc}")
+                        shutil.copytree(src_root, dst_root)
+
+                        # Optionally also sync library manifest to reflect version/capabilities
+                        man_src = lp / 'library.json'
+                        man_dst = libdir / 'library.json'
+                        try:
+                            if man_src.exists():
+                                shutil.copy2(man_src, man_dst)
+                                print(f"[precompile_wrapper] Updated library.json in libdeps from local project")
+                        except Exception as mexc:
+                            print(f"[precompile_wrapper] Note: could not update library.json: {mexc}")
+
+                        return True
+                # No local project found; keep packaged sources
+                return False
+            except Exception as e:
+                print(f"[precompile_wrapper] Note: could not sync C++ sources: {e}")
+                return False
+
+        # Password encryption/salt injection removed in v3.0.0
+
+        # Change working directory to the library so its relative paths resolve
+        os.chdir(str(lib_path))
+        print(f"[precompile_wrapper] Changed CWD to: {os.getcwd()}")
+        print(f"[precompile_wrapper] Running: {sys.executable} {precompile_script}")
+        
+        # Always try to ensure webui sources are available
+        try:
+            _ensure_webui_sources(lib_path)
+        except Exception as e_copy:
+            print(f"[precompile_wrapper] Note: could not ensure webui sources: {e_copy}")
+
+        # Ensure backend (C++) sources are synced from the local workspace if available
+        try:
+            synced = _sync_cpp_sources(lib_path)
+            if synced:
+                print("[precompile_wrapper] Using local backend sources")
+        except Exception as e_sync:
+            print(f"[precompile_wrapper] Note: C++ source sync step failed: {e_sync}")
+
+        # Ensure header generator is available where library expects it (lib/tools)
+        try:
+            lib_tools = lib_path / 'tools'
+            gen_src = project_dir / 'tools' / 'webui_to_header.js'
+            gen_dst = lib_tools / 'webui_to_header.js'
+            if gen_src.exists():
+                lib_tools.mkdir(parents=True, exist_ok=True)
+                with open(gen_src, 'rb') as fsrc, open(gen_dst, 'wb') as fdst:
+                    fdst.write(fsrc.read())
+                print(f"[precompile_wrapper] Provided header generator to library: {gen_dst}")
+        except Exception as e:
+            print(f"[precompile_wrapper] Warning: could not place header generator: {e}")
+
+        # Force fresh npm install if vite binary is missing
+        try:
+            wdir = lib_path / 'webui'
+            vite_bin = wdir / 'node_modules' / 'vite' / 'bin' / 'vite.js'
+            if not vite_bin.exists():
+                print("[precompile_wrapper] vite CLI missing; purging node_modules and package-lock.json to force reinstall")
+                import shutil
+                nm = wdir / 'node_modules'
+                if nm.exists():
+                    shutil.rmtree(nm)
+                plock = wdir / 'package-lock.json'
+                if plock.exists():
+                    try:
+                        plock.unlink()
+                    except Exception:
+                        pass
+                # Hint npm to force install
+                env_vars['npm_config_force'] = 'true'
+        except Exception as e:
+            print(f"[precompile_wrapper] Warning: could not purge node_modules: {e}")
+
+        # Ensure node_modules exists before proceeding
+        webui_dir = lib_path / 'webui'
+        node_modules_dir = webui_dir / 'node_modules'
+
+        log("[precompile_wrapper] Debug: Checking if SCons environment is available...")
+        if SCONS_AVAILABLE:
+            log("[precompile_wrapper] SCons environment detected.")
+        else:
+            log("[precompile_wrapper] SCons environment not detected. Running in standalone mode.")
+
+        log(f"[precompile_wrapper] Current working directory: {os.getcwd()}")
+        vlog(f"[precompile_wrapper] Environment variables: {os.environ}")
+
+        # Debugging library path
+        log(f"[precompile_wrapper] Calculated library path: {lib_path}")
+        if not lib_path.exists():
+            log(f"[precompile_wrapper] Library path does not exist: {lib_path}")
+
+        # Debugging precompile script path
+        log(f"[precompile_wrapper] Expected precompile script path: {precompile_script}")
+        if not precompile_script.exists():
+            log(f"[precompile_wrapper] Precompile script does not exist: {precompile_script}")
+
+        # Debugging node_modules check
+        log(f"[precompile_wrapper] Checking if node_modules exists at: {node_modules_dir}")
+        if not node_modules_dir.exists():
+            log("[precompile_wrapper] node_modules folder is missing. npm install will be attempted.")
+        else:
+            log("[precompile_wrapper] node_modules folder exists. Skipping npm install.")
+
+        result = subprocess.run([sys.executable, str(precompile_script)], 
+                                capture_output=False, 
+                                text=True,
+                                env=env_vars)
+        if result.returncode != 0:
+            print(f"[precompile_wrapper] Precompile script failed with return code: {result.returncode}")
+            sys.exit(result.returncode)
+        else:
+            print("[precompile_wrapper] ESP32 Configuration Manager precompile completed successfully")
+    except Exception as e:
+        print(f"[precompile_wrapper] Error running precompile script: {e}")
+        sys.exit(1)
+    finally:
+        os.chdir(original_cwd)
+
+# Catch any unhandled exceptions
+try:
+    main()
+except Exception as e:
+    log(f"[precompile_wrapper] Unhandled exception: {e}")
+    sys.exit(1)


### PR DESCRIPTION
## Summary
- update the BoilerSaver example dependencies and PlatformIO setup
- add Wokwi simulation files and a local precompile wrapper
- adjust BoilerSaver runtime settings and hardware defaults

## Validation
- pio run -d examples/BoilerSaver -e usb
- pio run -e usb

## Notes
- Version bump intentionally skipped per maintainer request.
- Changelog update intentionally skipped per maintainer request for this example-only update.