### PR TITLE
Clarify governance workflow rules

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,4 +1,3 @@
-
 # AGENTS.md
 
 Repository guidance for contributors and coding agents.
@@ -6,6 +5,46 @@ Repository guidance for contributors and coding agents.
 This repository is `ConfigurationsManager`, a C++/ESP32 project built with
 PlatformIO and the Arduino framework. The repository also contains a web UI and
 support tooling used by the embedded project.
+
+## Mandatory Governance Load Preflight
+
+Before executing any agent command, workflow shortcut, branch action,
+validation, file edit, commit, push, pull request, merge, release-branch update,
+or cleanup action, the agent MUST explicitly read the applicable governance
+files.
+
+Required reads:
+
+- `.github/AGENTS.md`
+- `.github/agents/<selected-agent>.agent.md`
+
+For workflow shortcuts, the selected agent is:
+
+- `.github/agents/workflow.agent.md`
+
+The agent MUST NOT rely on repository-wide search to discover these files,
+because hidden directories such as `.github/` may be skipped by default search
+tools.
+
+If governance files are known by path, read them directly instead of discovering
+them through search.
+
+If using ripgrep to inspect governance, the agent MUST include hidden paths, for
+example:
+
+rg --hidden -n "workflow\.begin|workflow\.audit|workflow\.toMain|workflow\.cleanBranches" .
+
+If using fd to inspect governance, the agent MUST include hidden paths, for
+example:
+
+fd --hidden "AGENTS|agent\.md|workflow\.agent\.md" .
+
+Plain `rg ... .` or plain `fd ... .` MUST NOT be treated as sufficient for
+governance discovery, because they may skip hidden directories such as
+`.github/`.
+
+Failure to read the required governance files is a hard blocker and must be
+reported before any further action.
 
 ## Communication
 
@@ -28,6 +67,20 @@ support tooling used by the embedded project.
   German.
 - If a specific artifact must be written in another language, require an
   explicit user request for that artifact.
+
+## User Text Normalization
+
+- User prompts may contain informal German, mixed German/English wording, and
+  obvious spelling mistakes.
+- Normalize free text into clean English when deriving branch names, issue/PR
+  titles, task labels, or governance wording.
+- Do not silently normalize exact paths, commands, symbols, identifiers,
+  explicitly provided names, issue/PR numbers, tags, versions, or quoted
+  literals.
+- If the user says to use a name exactly, preserve it.
+- Check quoted path casing against repository state.
+- If intent is unclear or normalization changes scope, stop and ask.
+- Example: `gevernance-sharpenes` may derive `governance-sharpening`.
 
 ## GitHub Text Language
 
@@ -116,6 +169,12 @@ support tooling used by the embedded project.
 - `release/*` branches are runnable snapshot branches and must stay buildable
   and runnable.
 - `release/*` branches are versioned by release, for example `release/v4.0.0`.
+- Do not assume `release/*` branches exist. Missing release branches do not
+  block normal pull-request based `main` integration unless release sync is
+  explicitly in scope.
+- If release sync is explicitly requested and no suitable release branch exists,
+  report that and skip the release update unless the user explicitly asks to
+  create or update a release branch.
 - `feature/*` branches are work-in-progress branches and may be unfinished or
   temporarily broken.
 - Do not change `main` directly.
@@ -131,6 +190,14 @@ support tooling used by the embedded project.
   exception.
 - Fast-forward integration to `main` is allowed only when the user explicitly
   requests fast-forward or `ff`.
+- Workflow shortcuts may be chained only in sequence. `workflow.audit` remains
+  strictly read-only and must finish by reporting blockers before any follow-up
+  shortcut runs.
+- If `workflow.audit` is followed by `workflow.toMain` or
+  `workflow.cleanBranches`, continue only when the user explicitly requested the
+  follow-up shortcut and no blockers remain.
+- If blockers remain after audit, stop before merge, cleanup, release updates,
+  or other destructive actions.
 - Before preparing or merging changes into `main`, perform a documentation
   impact check.
 - The documentation impact check must decide whether changed files or behavior
@@ -171,6 +238,19 @@ support tooling used by the embedded project.
   directory. For non-git commands that must change directory, use
   `Push-Location` / `Pop-Location`.
 - Prefer gh for PRs, CI checks, issues, and project operations when available.
+- For `workflow.toMain`, commit, push, pull request creation, pull request
+  merge, and branch cleanup are allowed only when explicitly requested by the
+  shortcut and only after repository state, validation needs, and documentation
+  impact have been checked.
+- Before merging to `main`, run or report relevant validation, perform the
+  documentation impact check, and report GitHub blockers such as required
+  reviews, failing checks, conflicts, or branch protection.
+- Owner/admin bypass may be used only when the user explicitly requested it for
+  the current action. Required status checks must not be bypassed unless the
+  user explicitly confirms that exception and the reason is reported.
+- For `workflow.cleanBranches`, delete only branches verified as integrated.
+  Do not delete active, unmerged, or ambiguous branches, and report skipped
+  branches with the reason.
 
 ## Pull Request Review Policy
 
@@ -239,6 +319,9 @@ support tooling used by the embedded project.
     changed
   - if that build succeeds, or was skipped because no `.cpp` or `.h` files
     changed, update the active `release/*` branch to match the work branch
+  - if no suitable release branch exists or no release branch is in scope,
+    report that and skip the release update unless the user explicitly asks to
+    create or update one
   - prefer fast-forward updates for the release branch
   - if fast-forward is not possible, ask explicitly before using
     `--force-with-lease`
@@ -330,14 +413,37 @@ follow this policy.
     available.
   - jq for JSON.
   - dasel for YAML, TOML, JSON, or XML inspection when it is the safest fit.
+- When searching for governance, agent instructions, workflow shortcuts, branch
+  rules, pull request rules, issue rules, validation rules, version rules, or
+  repository policy, include hidden paths.
+- For governance searches with rg, use `rg --hidden`.
+- For governance discovery with fd, use `fd --hidden`.
+- Plain `rg ... .` or plain `fd ... .` is not sufficient for governance
+  discovery because hidden directories such as `.github/` may be skipped.
+- When governance files are known by path, prefer reading those files directly
+  over discovering them through repository-wide search.
 - If rg or fd is missing, report that and give a simple install hint instead
   of silently using a weaker search path for audits or reference checks.
-- When reporting search results, include the rg pattern used.
+- When reporting search results, include the rg pattern used and state whether
+  hidden paths were included when governance, policy, workflow, or agent files
+  were in scope.
 - Do not assume every listed tool is installed on every machine. If a required
   tool is missing, report the failed command clearly.
 - Do not install or upgrade tools unless the user explicitly asks.
 - On Windows, do not assume sed or awk are available. Prefer
   PowerShell-native commands unless availability was confirmed.
+- Shell command quality:
+  - Prefer simple robust commands over complex shell-escaped one-liners.
+  - On Windows/PowerShell, prefer single quotes for regex/search patterns.
+  - Avoid PowerShell backticks in search patterns unless required.
+  - If quoting fails, retry once with safer quoting; do not repeat equivalent
+    broken commands.
+  - If quoting remains unclear, simplify, split the search, or read known files
+    directly.
+  - Do not treat failed commands as evidence about repository content.
+  - Distinguish command failure, no matches, missing files, and missing tools in
+    reports.
+  - Example: `rg --hidden -n 'workflow\.begin|workflow\.audit' .github`.
 - Use dasel for YAML, TOML, JSON, or XML inspection and edits when it is the
   safest fit.
 - Use jq for JSON.
@@ -348,8 +454,9 @@ follow this policy.
 - Do not mix jq and dasel syntax.
 - Do not use deprecated dasel flags.
 - Prefer structured tools over brittle text parsing when that reduces risk.
-- Do not assume repository, branch, PR, or project state. Verify with git and
-  gh.
+- Do not assume repository, branch, PR, project, or governance state. Verify
+  repository state with git and gh, and verify governance state by explicitly
+  reading the relevant governance files.
 
 ## Validation Baseline
 
@@ -363,6 +470,12 @@ follow this policy.
 - For affected examples, run the relevant example build.
 - If only Markdown or governance files changed, skip PlatformIO build unless the
   user asks for it.
+- Governance-only changes require a governance consistency check, but do not
+  require PlatformIO validation by themselves.
+- A governance consistency check means reading the affected governance files and
+  verifying that agent routing, shortcut rules, branch rules, tool policy,
+  validation rules, version rules, and reporting rules do not contradict each
+  other.
 - If tests are affected, run `pio test` for at least one relevant environment.
 - Run relevant tests when tests are present and affected.
 - Docker or image builds are not required unless configured in this repository
@@ -374,6 +487,8 @@ follow this policy.
 After file-changing work, report:
 
 - branch used
+- governance files read, when governance, workflow, branch, PR, merge, release,
+  validation, version, or cleanup rules were in scope
 - files changed
 - concise summary of what changed
 - validation run

--- a/.github/agents/docs.agent.md
+++ b/.github/agents/docs.agent.md
@@ -30,9 +30,10 @@ Markdown Rules:
   examples must still follow the global logging policy from `.github/AGENTS.md`.
 - Keep documentation concise and factual.
 - Documentation may refer to GitHub Issues or Pull Requests when useful.
-- Documentation must not assume that a GitHub Project exists.
-- If `.github/AGENTS.md` says `Current GitHub Project: none`, do not require
-  documentation synchronization with a project board.
+- Documentation must use the current configured GitHub Project from
+  `.github/AGENTS.md` when project coordination is explicitly in scope.
+- Project-board actions remain optional unless the user asks for tracked
+  workflow or the task explicitly uses project coordination.
 - Do not create a parallel task tracker in Markdown when GitHub Issues, PRs, or a
   configured GitHub Project are intentionally being used for the work.
 

--- a/.github/agents/refactor.agent.md
+++ b/.github/agents/refactor.agent.md
@@ -1,6 +1,25 @@
 # Refactor Agent
 
-Purpose:
+## Mandatory governance load preflight
+
+Before executing any agent command, workflow shortcut, branch action, validation, file edit, or merge action, the agent MUST read the relevant governance files explicitly.
+
+Required reads:
+
+- `.github/AGENTS.md`
+- `.github/agents/<selected-agent>.agent.md`
+
+For workflow shortcuts, the selected agent is:
+
+- `.github/agents/workflow.agent.md`
+
+The agent MUST NOT rely on repository-wide search to discover these files, because `.github/` may be hidden from default search tools.
+
+If using ripgrep to inspect governance, the agent MUST use `--hidden`, for example:
+
+- rg --hidden -n "workflow\.begin|workflow\.audit|workflow\.toMain|workflow\.cleanBranches" .
+
+## Purpose:
 Perform safe C++/ESP32/PlatformIO code changes and structural improvements
 without unintended behavior changes.
 
@@ -13,7 +32,7 @@ Use this agent for:
 - build and test validation
 - PlatformIO configuration changes when explicitly in scope
 
-Scope:
+## Scope:
 
 - Preserve external behavior unless the user explicitly asks for behavior change.
 - Keep changes small and coherent.
@@ -22,10 +41,13 @@ Scope:
   behavior, or build pipelines without explicit confirmation.
 - Keep hardware-facing changes conservative and easy to verify.
 
-Branch And Workflow:
+## Branch And Workflow:
 
 - Use `workflow.agent.md` for branch creation, checkpointing, PRs, release
   updates, and branch cleanup.
+- When a refactor task needs branch, issue, PR, or task-label wording, follow
+  the user text normalization and branch-name derivation rules from
+  `.github/AGENTS.md` and `workflow.agent.md`.
 - Do not stage, commit, switch branches, merge, rebase, stash, clean, or push
   unless explicitly requested or directed by a workflow shortcut.
 - If the active branch is `main` or `master` and file-changing work is
@@ -35,42 +57,13 @@ Branch And Workflow:
   requested docs-only TODO update under `docs/TODO.md` or `docs/todo_*.md`.
 - Work on one side branch at a time.
 
-Version Handling:
+## Version Handling:
 
-- Dependency updates, PlatformIO configuration changes, library metadata
-  changes, firmware code changes, and example changes that affect build outputs
-  require an appropriate project version bump unless the user explicitly says
-  not to bump.
-- Governance-only and documentation-only changes do not require a version bump.
-  Report that the version bump was skipped by policy.
-- Use patch bumps for dependency updates, bug fixes, internal compatible
-  changes, and build or configuration maintenance with no public API break.
-- Use minor bumps for new public features, new examples, new public APIs, and
-  compatible behavior additions.
-- Use major bumps for breaking public API changes, incompatible storage/NVS
-  layout changes, incompatible configuration schema changes, and behavior
-  changes requiring user migration.
-- Before changing versions, search for version declarations and report the
-  candidate files found.
-- If multiple version declarations exist, report them before changing versions.
-- Bump library or project version declarations for dependency and build metadata
-  changes. Do not automatically bump independent example firmware or app
-  versions.
-- Treat the ConfigurationsManager package/library version as the main project
-  version.
-- Treat the WebUI package under `webui/` as part of the repository build
-  artifact, not as an independent example firmware or app.
-- When WebUI npm dependencies, WebUI build metadata, or WebUI package metadata
-  change, align the WebUI package version with the ConfigurationsManager
-  package/library version.
-- Bump an example firmware or app version only when that example itself is
-  intentionally changed or released.
-- If the version source of truth is unclear, stop and report candidate files
-  instead of guessing.
-- If version ownership is unclear, stop and report candidate files instead of
-  guessing.
+- Follow the central Version Policy in `.github/AGENTS.md`.
+- Refactor work must not change versions unless the central policy requires it
+  or the user explicitly requests it.
 
-Rename Safety:
+## Rename Safety:
 
 - Before any API rename, search all references with rg.
 - After a rename, rerun rg to confirm old names do not remain in relevant
@@ -79,7 +72,7 @@ Rename Safety:
   `test/`, `docs/`, or examples when present.
 - Report the rg pattern used for reference checks.
 
-Logging Changes:
+## Logging Changes:
 
 - Follow the global logging policy in `.github/AGENTS.md`.
 - Keep API renames and logging normalization separate.
@@ -87,7 +80,7 @@ Logging Changes:
 - Hardware-level logs should default to `[D]` or `[T]` unless a higher severity
   is technically justified.
 
-Testing And Build Validation:
+## Testing And Build Validation:
 
 - Run at least one PlatformIO build after `.cpp` or `.h` changes.
 - Default validation:
@@ -109,7 +102,7 @@ Testing And Build Validation:
   `[MOCKED!]`.
 - If validation cannot be run, report the reason plainly.
 
-Reporting:
+## Reporting:
 
 - Inspect relevant diffs before reporting file-changing work.
 - Do not paste full diffs into chat unless the user explicitly asks for the full
@@ -119,8 +112,10 @@ Reporting:
 - Prefer `git diff --stat` or focused summaries for reporting.
 - Include focused diff snippets only when needed to explain a risky, ambiguous,
   or important change.
+- Follow the central Shell Command Quality rules when running search,
+  validation, or audit commands.
 
-Strict Stops:
+## Strict Stops:
 
 - Stop if behavior would change but the request was refactor-only.
 - Stop if repository state, branch scope, or user edits make the safe edit path

--- a/.github/agents/workflow.agent.md
+++ b/.github/agents/workflow.agent.md
@@ -6,6 +6,25 @@ release branches, and explicit session-close handling.
 
 This agent must apply `.github/AGENTS.md`.
 
+## Mandatory governance load
+
+Before executing any agent command, workflow shortcut, branch action, validation, file edit, or merge action, the agent MUST read the relevant governance files explicitly.
+
+Required reads:
+
+- `.github/AGENTS.md`
+- `.github/agents/<selected-agent>.agent.md`
+
+For workflow shortcuts, the selected agent is:
+
+- `.github/agents/workflow.agent.md`
+
+The agent MUST NOT rely on repository-wide search to discover these files, because `.github/` may be hidden from default search tools.
+
+If using ripgrep to inspect governance, the agent MUST use `--hidden`, for example:
+
+- rg --hidden -n "workflow\.begin|workflow\.audit|workflow\.toMain|workflow\.cleanBranches" .
+
 ## Branch Model
 
 - `main` is the published/released branch.
@@ -13,6 +32,11 @@ This agent must apply `.github/AGENTS.md`.
   runnable.
 - `release/*` branches are versioned by release, for example `release/v4.0.0`
   or `release/v4.1.0`.
+- Do not assume `release/*` branches exist. If no suitable release branch
+  exists, report that and skip release-branch updates unless the user explicitly
+  asks to create or update one.
+- Missing release branches do not block normal pull-request based `main`
+  integration unless release sync is explicitly in scope.
 - `feature/*` branches are work-in-progress branches and may be unfinished or
   temporarily broken.
 - Work on one side branch at a time.
@@ -68,6 +92,30 @@ This agent must apply `.github/AGENTS.md`.
   names instead of silently switching.
 - Never revert user edits unless explicitly asked.
 
+## Branch Name And Title Derivation
+
+- Derive branch names, issue titles, pull request titles, and task labels from
+  the task intent, not by blindly copying informal free text.
+- Correct obvious spelling mistakes in user-provided free text when the intended
+  meaning is clear.
+- Prefer short, clean English, lowercase, hyphen-separated branch names under
+  the appropriate prefix, usually `feature/`.
+- Do not silently correct exact file paths, commands, symbols, identifiers,
+  branch names, issue numbers, pull request numbers, tags, versions, or quoted
+  literals.
+- If the user explicitly provides an exact branch name and says to use it
+  exactly, preserve it as written.
+- If the requested wording is ambiguous, or a correction would materially change
+  the task scope, stop and ask before creating or switching branches.
+- Check quoted paths against repository state before treating different casing
+  as a typo. For example, `.github/agents.md` and `.github/AGENTS.md` may be a
+  casing issue rather than interchangeable paths on every platform.
+- Examples:
+  - `use workflow.begin [gevernance-sharpenes]` may derive
+    `feature/governance-sharpening`.
+  - `use workflow.begin [update boilersaver example]` may derive
+    `feature/update-boilersaver-example`.
+
 ## GitHub Workflow
 
 - Prefer gh for PRs, CI checks, and issues when available.
@@ -102,15 +150,10 @@ This agent must apply `.github/AGENTS.md`.
   reason to create German GitHub issue or PR text by default.
 - Use GitHub Issues or PRs as task tracking when the user asks for tracked
   workflow, but do not invent mandatory project-board rules for this repository.
-- GitHub Project usage is optional and controlled by `.github/AGENTS.md`
-  `Tracking Policy`.
-- When `Current GitHub Project` is `none`:
-  - do not require project-board actions
-  - do not report missing project-board state as a blocker
-  - do not require project item status changes
-  - do not require documentation or TODO synchronization into a project board
-- When a concrete GitHub Project is configured later, workflow rules may use it
-  as an optional coordination mechanism for issue, PR, and project status.
+- GitHub Project usage is optional and controlled by the current configured
+  project in `.github/AGENTS.md` `Tracking Policy`.
+- Project-board actions remain optional unless the user asks for tracked
+  workflow or the task explicitly uses project coordination.
 - Issues and PRs remain allowed regardless of GitHub Project configuration.
 
 ## PlatformIO Workflow
@@ -183,6 +226,11 @@ This agent must apply `.github/AGENTS.md`.
 ## Release Branch Workflow
 
 - `release/*` branches should represent runnable snapshots.
+- Do not assume a release branch exists.
+- If no suitable release branch exists, report that and skip release-branch
+  update unless the user explicitly asks to create or update one.
+- Missing release branches do not block PR-based `main` integration unless
+  release sync was explicitly in scope.
 - Prefer fast-forward updates when moving a release branch to a verified feature
   state.
 - If fast-forward is not possible, ask explicitly before force-pushing. Prefer
@@ -195,10 +243,27 @@ This agent must apply `.github/AGENTS.md`.
 
 These names describe expected intent if the user invokes them:
 
-- `workflow.begin`: prepare the correct branch for a new task.
+- `workflow.begin`:
+  - create the appropriate branch according to branch policy
+  - derive a suitable clean English branch name from the task intent
+  - avoid propagating obvious spelling mistakes from informal free text
+  - preserve an exact branch name only when the user explicitly says to use that
+    exact branch name
+  - report the derived branch name before or immediately after creating it
+  - mention when obvious typos were normalized, when relevant
+  - do not perform code edits
+  - do not perform build changes
+  - do not run implementation work unless the user explicitly asks after the branch exists
 - `workflow.checkpoint`: create a commit and push the current coherent state.
 - `workflow.docs`: perform a narrow documentation-only synchronization.
 - `workflow.audit`: read-only workflow or repository-state audit.
+  - read-only only
+  - no file changes
+  - no branch changes
+  - no commits
+  - no merges
+  - if followed by `workflow.toMain` or `workflow.cleanBranches`, finish the
+    audit first and report blockers before any follow-up workflow runs
 - `workflow.ship`: build and verify artifacts without implicit merge.
 - `workflow.ready`: prepare work for review or integration, run or report
   relevant validation, do not merge to `main`, do not update `release/*`, and do
@@ -206,7 +271,19 @@ These names describe expected intent if the user invokes them:
 - `workflow.toMain`: get validated work onto `main` through the agreed pull
   request workflow unless the user explicitly requested fast-forward or `ff`;
   perform the documentation impact check before merging.
+  - commit, push, PR creation, PR merge, and branch cleanup are allowed only as
+    part of this explicitly requested workflow
+  - run or report relevant validation before merge
+  - perform the documentation impact check before merge
+  - report GitHub blockers before merge, including required reviews, failing
+    checks, conflicts, and branch protection
+  - use owner/admin bypass only when the user explicitly requested it for the
+    current action
+  - do not bypass required status checks unless the user explicitly confirmed
+    that exception and the reason is reported
 - `workflow.cleanBranches`: delete only branches verified as integrated.
+  - do not delete active, unmerged, or ambiguous branches
+  - report skipped branches with the reason
 - `workflow.end`: inspect repository state and report current branch, changed
   files, validation state, and blockers without claiming merge or fix success.
   Do not commit, push, merge, or update release branches unless explicitly
@@ -218,6 +295,12 @@ Shortcut behavior must remain conservative:
 - Avoid destructive operations.
 - Report blockers plainly.
 - Do not create parallel branch lines for the same work.
+- Chained shortcuts run sequentially. If audit blockers remain, stop before
+  merge, cleanup, release updates, or destructive actions.
+- Follow-up workflows after `workflow.audit` may run only when the user
+  explicitly requested them and no blockers remain.
+- Follow the central Shell Command Quality rules for search, validation, and
+  audit commands.
 
 ## Mandatory Reporting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,244 +1,40 @@
-Role:
-you are my coding assistant. Follow the instructions in this file carefully when generating code.
+# Root Agent Instructions
 
-========================================
-COMMUNICATION STYLE
-========================================
-- Use informal tone with "you" (not "Sie" or formal language)
-- Answer in German
-- Give only a brief overview after completing tasks
-- Provide detailed explanations only when explicitly asked
+This root file exists for tools that load repository-root `AGENTS.md` before
+repository-specific governance.
 
-========================================
-SEMI-AUTOMATIC WORKFLOW GUIDELINES
-========================================
-- User changes are sacred:
-  - Never revert or overwrite user edits without asking first.
+## Canonical Governance
 
-- Confirm-before-write:
-  - If requirements are ambiguous or the change impacts multiple subsystems/files,
-    ask 1–3 precise clarifying questions or propose 2–3 options before editing.
+- `.github/AGENTS.md` is the canonical repository governance file.
+- Before repository work, read `.github/AGENTS.md` and the applicable
+  `.github/agents/*.agent.md` file directly.
+- Do not rely on repository-wide search to discover governance files; read known
+  governance paths directly.
+- If this file conflicts with `.github/AGENTS.md`, follow `.github/AGENTS.md`.
+- Defer to `.github/AGENTS.md` for repository workflow, branch, pull request,
+  merge, release, validation, version, tool, and agent-routing rules.
 
-- One side-branch at a time:
-  - Do not work on more than one side-branch simultaneously.
+## Communication
 
-- Step-by-step workflow:
-  - Implement changes incrementally in small steps:
-    fix → verify → commit → continue.
+- Use informal German ("du") in normal chat with the user.
+- Keep user-facing summaries brief unless detailed explanation is requested.
+- Repository artifacts, code comments, commit messages, issue text, pull request
+  text, and generated governance text follow the language rules in
+  `.github/AGENTS.md`.
 
-- Do not revert user edits unless asked:
-  - Even if unrelated to the current topic.
+## Safety Baseline
 
-- Autonomy levels:
-  - Level A (safe): Read-only actions (search, read, analyze) may be done immediately.
-  - Level B (normal): Small, clearly scoped changes (1–2 files, obvious fix) may be implemented immediately.
-  - Level C (risky): Changes involving settings structure/storage/NVS, OTA, security,
-    build pipelines, or large refactors REQUIRE explicit confirmation.
+- User changes are sacred. Never revert or overwrite user edits without explicit
+  request.
+- Do not stage, commit, push, merge, rebase, reset, clean, stash, switch
+  branches, or update release branches unless the user explicitly requests it or
+  a named workflow in `.github/AGENTS.md` requires it.
+- Do not work directly on `main` or `master` except for the narrow exceptions
+  defined in `.github/AGENTS.md`.
+- Do not run upload, monitor, destructive, or hardware/network-affecting
+  commands unless explicitly requested.
 
-- Safety gates:
-  - Before rename/delete: always search references and update them.
-  - Before running terminal commands that modify the workspace: ensure goal and scope are clear.
+## Final Rule
 
-========================================
-GIT WORKFLOW GUIDELINES
-========================================
-- Branch roles in this repository:
-  - main:
-    - published / released branch
-  - release/*:
-    - runnable snapshot branches
-    - must always be buildable and runnable
-    - versioned by release (e.g. release/v4.0.0, release/v4.1.0, ...)
-  - feature/*:
-    - work-in-progress branches
-    - may be unfinished or temporarily broken
-
-- "Feierabend" workflow trigger:
-  - If the user says:
-    "ich mach jetzt feierabend" or "ich will jetzt feierabend machen"
-  - Treat this as an end-of-session cue.
-
-  Default behavior:
-  - Commit the current work branch (feature/*).
-  - use git add -A and a meaningful commit message.
-  - Push the work branch to origin.
-  - Run a PlatformIO build in the repo root:
-      pio run -e usb
-    (must succeed without errors).
-    - Exception: If no `.cpp` or `.h` files were changed, skip this build step.
-  - Only if the build succeeds (or was skipped due to no `.cpp`/`.h` changes):
-    - Update the active release/* branch to match the work branch exactly.
-    - Prefer fast-forward updates.
-    - If fast-forward is not possible, ask explicitly before force-pushing
-      (push --force-with-lease).
-  - Push the updated release/* branch.
-
-- Never change main directly:
-  - If the active branch is main/master:
-    - Emit a [WARNUNG] warning
-    - use git add -A and a meaningful commit message, if user has changed files.
-
-- Exception:
-  - Docs-only TODO updates (docs/TODO.md, docs/todo_*.md)
-    may be committed directly to main.
-
-- Git command rules:
-  - Read-only git commands may be run without asking:
-    git status, git diff, git log, git show, git branch, git remote -v
-  - Commands that modify history or working tree require confirmation:
-    git add, commit, switch/checkout, reset, merge, rebase, clean, stash, cherry-pick
-
-- Staging / committing:
-  - Stage/commit/push ONLY on explicit user request.
-  - If staging is requested, prefer:
-    git add -A
-
-- Command execution style:
-  - Do NOT prepend Set-Location for git commands.
-  - Only change directories when required for non-git commands.
-  - Use Push-Location / Pop-Location to restore the original directory.
-
-- Large changes require a clean baseline:
-  - Before multi-file refactors or risky changes, ensure work is committed or stashed.
-  - Branch naming check:
-    - Verify the active branch matches the topic.
-    - If not, emit a [W] warning and propose 2–3 suitable branch names.
-
-
-- GitHub CLI:
-  - Prefer gh for PRs, CI checks, issues, when available.
-
-========================================
-CODE STYLE (STRICT, GLOBAL)
-========================================
-- All code comments in English only
-- Clear, descriptive variable names (English only)
-- All function names in English only
-- All error and log messages in English
-- Emojis are forbidden everywhere:
-  - code
-  - comments
-  - log messages
-  - outputs
-
-----------------------------------------
-DOCUMENTATION EXCEPTION (.md FILES)
-----------------------------------------
-- The strict logging severity and efficiency rules apply to:
-  - source code
-  - headers
-  - examples
-  - tests
-
-- Markdown documentation files (*.md) are EXEMPT from strict logging rules:
-  - Readability and clarity have priority over flash optimization.
-  - Long-form tags like [WARNING], [NOTE], [INFO] are allowed in prose text.
-
-- IMPORTANT:
-  - Code blocks inside Markdown files (```cpp, ```c, ```text, etc.)
-    MUST still follow the Global Logging Severity & Efficiency Policy.
-  - Only narrative documentation text is exempt, not code examples.
-
-========================================
-GLOBAL LOGGING SEVERITY & EFFICIENCY POLICY
-(ESP32 / Flash-Optimized, Mandatory)
-========================================
-- ALL log messages MUST use short, ASCII-only severity tags.
-- Allowed severity tags:
-  - [E] = Error
-  - [W] = Warning
-  - [I] = Info
-  - [D] = Debug
-  - [T] = Trace
-
-- Long tags are FORBIDDEN everywhere:
-  - [ERROR], [WARNING], [INFO], [DEBUG], [SUCCESS], etc.
-
-- Verbose is NOT a severity level:
-  - Verbose controls WHETHER logs are emitted.
-  - Severity tags describe WHAT the log means.
-
-- Severity reassignment is ALLOWED:
-  - The agent MAY change severity levels
-    (e.g. [W] → [D]) if technically justified.
-  - Severity must reflect the actual relevance and impact of the message.
-
-- Logging text changes are NOT API renames:
-  - Log message updates do NOT count as public API changes.
-  - Rename safety rules do NOT apply to log text.
-
-----------------------------------------
-LOG MESSAGE EFFICIENCY RULE
-----------------------------------------
-- Log messages must be semantically clear but as short as reasonably possible.
-- Prefer compression over verbosity to reduce flash usage.
-- Avoid filler words when meaning remains clear:
-  - "already exists" → "exists"
-  - "both enabled" → "both ON"
-  - "using pull-up" → "use pull-up"
-- Prefer standard abbreviations:
-  - cfg, init, ok, fail, pull-up/down, adc, pwm, io
-- Do NOT repeat information already encoded by:
-  - severity tag
-  - module prefix ([IO], [CM], etc.)
-  - surrounding context
-
-----------------------------------------
-LOW-LEVEL LOGGING GUIDANCE
-----------------------------------------
-- IO and hardware-level logs are typically debug- or trace-oriented.
-- Treat LOG output as [D] or [T] by default.
-- Prefer [W] only for notable but recoverable conditions.
-- Use [E] only for critical IO failures.
-
-========================================
-RENAME & LOGGING INTERACTION (PHASE RULE)
-========================================
-- API renames and logging normalization MUST be treated as separate concerns.
-- Logging normalization MUST NOT be mixed with API renaming phases.
-- Log text changes do NOT trigger rename safety rules.
-
-========================================
-TOOLING & SEARCH POLICY
-========================================
-- Preferred search tool:
-  - ALWAYS use ripgrep (rg) for code searches, audits, and reference checks.
-    - if is not installed, give instructions to install it first. (choco install ripgrep)
-  - ALWAYS use sharkdp.fd (fd) for file searches, audits, and reference checks.
-    - if is not installed, give instructions to install it first. (winget install sharkdp.fd)
-- When reporting search results:
-  - Include the rg pattern used.
-
-- Windows compatibility:
-  - Do NOT assume sed or awk are available.
-  - Prefer PowerShell-native commands for replacements and filtering.
-  - sed/awk may be used ONLY if explicitly available and confirmed.
-
-========================================
-RENAME SAFETY RULE
-========================================
-- Before any API rename:
-  - Perform a full reference search using rg.
-- After renaming:
-  - Re-run rg to ensure no old names remain.
-- A rename is incomplete if any reference remains in:
-  - src/
-  - include/
-  - examples/
-  - docs/
-  - tests/
-
-========================================
-TESTING & BUILD VALIDATION
-========================================
-- Unit tests for core components
-- Mock implementations for testing
-  - mocked data must be clearly marked as [MOCKED!]
-- Always run at least one PlatformIO build after changes.
-  - Exception: If no `.cpp` or `.h` files were changed, do not run `pio run`.
-- If tests are affected, run pio test for at least one environment.
-
-========================================
-FINAL RULE
-========================================
-- Never mark an issue as solved or fixed until the user explicitly confirms it works.
+- Never mark an issue as solved or fixed until the user explicitly confirms it
+  works.


### PR DESCRIPTION
## Summary
- Rename the canonical governance file to `.github/AGENTS.md`.
- Make the root `AGENTS.md` defer to the central governance file.
- Clarify workflow shortcut chaining, `workflow.toMain`, branch cleanup, release-branch absence handling, project wording, typo normalization, and shell command quality guidance.

## Validation
- Read `.github/AGENTS.md`, root `AGENTS.md`, and all `.github/agents/*.agent.md` files.
- Ran hidden-path governance searches with `rg --hidden`.
- Ran `git diff --check`.
- Skipped PlatformIO build because the changes are governance-only and no `.cpp` or `.h` files changed.

## Notes
- No version bump: governance-only changes do not require a version bump by policy.
- No changelog update: this repository does not track governance-only changes in the changelog.