### PR TITLE
Fix webserver route re-registration

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This changelog is a curated overview.
 
+## 4.0.5
+
+- Web and HTTP OTA routes are now registered only once, preventing repeated
+  WiFi reconnects from growing the AsyncWebServer handler list.
+- WebSocket live updates now default to a 1000 ms interval and skip runtime JSON
+  generation while no WebSocket clients are connected.
+
 ## 4.0.4
 
 - OTA uploads now hold an active OTA guard so WiFi roaming scans, reconnect

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32 Configuration Manager",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "keywords": "esp32, configuration, wifi, web-server, ota, iot, automation",
   "description": "Robust configuration management system with web interface for ESP32 and ota support.",
   "repository": {

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -44,7 +44,7 @@ public:
 };
 #endif
 
-#define CONFIGMANAGER_VERSION "4.0.4" // Synced to library.json
+#define CONFIGMANAGER_VERSION "4.0.5" // Synced to library.json
 
 #if CM_ENABLE_THEMING && CM_ENABLE_STYLE_RULES
 inline constexpr char CM_DEFAULT_RUNTIME_STYLE_CSS[] PROGMEM = R"CSS(
@@ -1905,7 +1905,7 @@ public:
     bool wsInitialized = false;
     bool wsEnabled = false;
     bool pushOnConnect = true;
-    uint32_t wsInterval = 2000;
+    uint32_t wsInterval = 1000;
 
     unsigned long wsLastPush = 0;
     std::function<String()> customPayloadBuilder;
@@ -2696,7 +2696,7 @@ public:
         webManager.begin(this);
         otaManager.begin(this);
         runtimeManager.begin(this);
-        WebSocketPush(true, 250);
+        WebSocketPush(true);
         setPushOnConnect(true);
         if (BaseSetting *otaEnable = findSettingByKeyHint("System", "OTAEn"); otaEnable && otaEnable->getType() == SettingType::BOOL)
         {
@@ -2765,7 +2765,7 @@ public:
         webManager.begin(this);
         otaManager.begin(this);
         runtimeManager.begin(this);
-        WebSocketPush(true, 250);
+        WebSocketPush(true);
         setPushOnConnect(true);
         if (BaseSetting *otaEnable = findSettingByKeyHint("System", "OTAEn"); otaEnable && otaEnable->getType() == SettingType::BOOL)
         {
@@ -2800,7 +2800,7 @@ public:
 
         webManager.begin(this);
         runtimeManager.begin(this);
-        WebSocketPush(true, 250);
+        WebSocketPush(true);
         setPushOnConnect(true);
         if (BaseSetting *otaEnable = findSettingByKeyHint("System", "OTAEn"); otaEnable && otaEnable->getType() == SettingType::BOOL)
         {
@@ -3185,8 +3185,12 @@ public:
 
     void handleWebsocketPush()
     {
-        if (!wsEnabled)
+        if (!wsEnabled || !ws)
             return;
+        wsHeartbeatMaintenance();
+        if (wsClients.empty())
+            return;
+
         unsigned long now = millis();
         if (now - wsLastPush < wsInterval)
             return;
@@ -3203,11 +3207,9 @@ public:
         }
 
         sendWebSocketText(payload);
-        // Run manual heartbeat maintenance
-        wsHeartbeatMaintenance();
     }
 
-    void enableWebSocketPush(uint32_t intervalMs = 2000)
+    void enableWebSocketPush(uint32_t intervalMs = 1000)
     {
         if (!wsInitialized)
         {
@@ -3273,7 +3275,7 @@ public:
     void setWebSocketInterval(uint32_t intervalMs) { wsInterval = intervalMs; }
     void setPushOnConnect(bool v) { pushOnConnect = v; }
     void setCustomLivePayloadBuilder(std::function<String()> fn) { customPayloadBuilder = fn; }
-    void WebSocketPush(bool enable = true, uint32_t intervalMs = 2000)
+    void WebSocketPush(bool enable = true, uint32_t intervalMs = 1000)
     {
 #if CM_ENABLE_WS_PUSH
         if (enable) {
@@ -3288,7 +3290,7 @@ public:
     }
 #else
     void handleWebsocketPush() {}
-    void enableWebSocketPush(uint32_t = 2000) {}
+    void enableWebSocketPush(uint32_t = 1000) {}
     void disableWebSocketPush() {}
     void setWebSocketInterval(uint32_t) {}
     void setPushOnConnect(bool) {}

--- a/src/ota/OTAManager.cpp
+++ b/src/ota/OTAManager.cpp
@@ -8,6 +8,7 @@ ConfigManagerOTA::ConfigManagerOTA()
     : otaEnabled(false)
     , otaInitialized(false)
     , otaActive(false)
+    , webRoutesConfigured(false)
     , configManager(nullptr)
 {
 }
@@ -132,6 +133,10 @@ bool ConfigManagerOTA::isActive() const {
 
 void ConfigManagerOTA::setupWebRoutes(AsyncWebServer* server) {
     if (!server) return;
+    if (webRoutesConfigured) {
+        OTA_LOG("[D] Web routes already configured");
+        return;
+    }
 
     // OTA upload endpoint
     server->on("/ota_update", HTTP_GET,
@@ -153,7 +158,8 @@ void ConfigManagerOTA::setupWebRoutes(AsyncWebServer* server) {
         }
     );
 
-    OTA_LOG("Web routes configured");
+    webRoutesConfigured = true;
+    OTA_LOG("[I] Web routes configured");
 }
 
 void ConfigManagerOTA::handleOTAUpload(AsyncWebServerRequest* request) {

--- a/src/ota/OTAManager.h
+++ b/src/ota/OTAManager.h
@@ -31,6 +31,7 @@ private:
     bool otaEnabled;
     bool otaInitialized;
     bool otaActive;
+    bool webRoutesConfigured;
     String otaPassword;
     String otaHostname;
     ConfigManagerClass* configManager;

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -13,6 +13,8 @@ ConfigManagerWeb::ConfigManagerWeb(AsyncWebServer* webServer)
     : server(webServer)
     , configManager(nullptr)
     , initialized(false)
+    , routesDefined(false)
+    , serverStarted(false)
     , embedWebUI(CM_EMBED_WEBUI ? true : false)
     , customHTML(nullptr)
     , customHTMLLen(0)
@@ -120,19 +122,28 @@ bool ConfigManagerWeb::isStarted() const {
 
 void ConfigManagerWeb::defineAllRoutes() {
     if (!initialized || !server) {
-        WEB_LOG("Cannot define routes - not initialized");
+        WEB_LOG("[W] Cannot define routes - not initialized");
         return;
     }
 
-    setupStaticRoutes();
-    setupAPIRoutes();
-    setupRuntimeRoutes();
+    if (!routesDefined) {
+        setupStaticRoutes();
+        setupAPIRoutes();
+        setupRuntimeRoutes();
+        routesDefined = true;
 
-    WEB_LOG("All routes defined");
+        WEB_LOG("[I] All routes defined");
+    } else {
+        WEB_LOG_VERBOSE("[D] Routes already defined");
+    }
 
-    // Start the server
-    server->begin();
-    WEB_LOG("Server started on port 80");
+    if (!serverStarted) {
+        server->begin();
+        serverStarted = true;
+        WEB_LOG("[I] Server started on port 80");
+    } else {
+        WEB_LOG_VERBOSE("[D] Server already started");
+    }
 }
 
 void ConfigManagerWeb::setupStaticRoutes() {

--- a/src/web/WebServer.h
+++ b/src/web/WebServer.h
@@ -24,6 +24,8 @@ private:
     AsyncWebServer* server;
     ConfigManagerClass* configManager;
     bool initialized;
+    bool routesDefined;
+    bool serverStarted;
 
     // Callbacks for ConfigManager integration
     JsonProvider configJsonProvider;

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "esp32-config-webui",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "esp32-config-webui",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "dependencies": {
         "vue": "^3.5.34"
       },

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esp32-config-webui",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Register ConfigManager web routes and HTTP OTA routes only once to avoid AsyncWebServer handler growth across WiFi reconnects.
- Change WebSocket live push defaults to 1000 ms and skip runtime JSON generation when no WebSocket clients are connected.
- Bump ConfigurationsManager/WebUI package version to 4.0.5 and document the fix in the changelog.

## Validation
- `pio run -e usb` from repository root
- `pio run -e usb` from `examples/SolarInverterLimiter`

## Notes
- `examples/SolarInverterLimiter/platformio.ini` had local unstaged edits and was intentionally left out of this PR.