### PR TITLE
Update SolarInverterLimiter example

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This changelog is a curated overview.
 
+## 4.0.6
+
+- SolarInverterLimiter example now defaults to ConfigurationsManager 4.0.5 and
+  keeps relay output code behind compile-time feature flags to reduce firmware
+  size when fan and heater outputs are unused.
+- SolarInverterLimiter firmware version bumped to 4.2.0.
+
 ## 4.0.5
 
 - Web and HTTP OTA routes are now registered only once, preventing repeated

--- a/examples/SolarInverterLimiter/docs/todo.md
+++ b/examples/SolarInverterLimiter/docs/todo.md
@@ -11,31 +11,51 @@ Legend:
 
 ## P0 (critical) – Anglicize the project (repo-wide)
 
-
-
-- [COMPLETED] Ensure English-only repository artifacts
-	- Review /docs/* and translate remaining German text to English
-	- Review /dev-info/* and translate remaining German text to English (keep technical meaning)
-	- Review /src/* and translate remaining German comments/strings to English
-	- Replace emojis in repository artifacts with plain text tags like [INFO]/[WARNING]/[ERROR]
-	- Ensure new documentation is written in English (chat explanations remain German)
-
-
-- [CURRENT] Rename non-English/typo identifiers (incremental)
-	- Replace German variable/function names with English equivalents (update all references)
-	- Keep external interfaces stable (MQTT topics/JSON keys) unless explicitly intended
-
-
-- [COMPLETED] Align project guidance
-	- Keep language policy consistent across README, docs, and .github instructions
-	- Remove outdated or misleading usage text (e.g. references to non-existing config_example.h)
+- no critical features
 
 ## P0 (critical) – ConfigManager refactor (functional, buildable)
 
-- [COMPLETED] ConfigManager refactor aligned to ConfigManager 4.0.0
-	- Settings migrated to ConfigOptions API (no builder)
-	- Runtime/WiFi APIs aligned
-	- `pio run -e usb` builds successfully
-	- Note: No backward compatibility / migration by explicit decision
+- no critical features for CM
 
 ## P1 (high) – Update HomeAssistant YAML to the new structure
+
+## P1 (high) – Reduce firmware flash usage
+
+- [NEXT] Evaluate OLED display stack replacement
+	- Current assessment: replacing `Adafruit SSD1306` + `Adafruit GFX` is likely worth about 12-16 KB Flash and 1024 B RAM with a text-only OLED library
+	- Alternative assessment: a lighter graphics/text library with similar layout is likely worth about 6-10 KB Flash
+	- Current display usage is mostly text plus a simple frame, so a smaller display stack should preserve user-visible behavior
+	- Bigger flash savings are more likely in the embedded ConfigManager WebUI, but that is a separate larger effort
+
+## P1 (high) – Add asymmetric inverter setpoint ramp limiting
+
+- [NEXT] Add an asymmetric slew-rate / ramp limiter after the PID or setpoint calculation
+	- Apply the limiter after the calculated target setpoint is clamped to `minInverterPower` and `maxInverterPower`
+	- Use separate configurable settings instead of hardcoded values:
+		- `maxSetpointRiseWattsPerSecond`
+		- `maxSetpointFallWattsPerSecond`
+	- Rising setpoint should be slower
+	- Falling setpoint should be faster
+	- This is an output conditioning layer after the PID / setpoint calculation, not a replacement for PID tuning
+	- Why this is useful:
+		- fast down-ramp reduces the risk of unwanted feed-in when consumption drops
+		- slow up-ramp avoids reacting too aggressively to short consumption spikes
+	- Suggested flow:
+		```text
+		calculatedTarget = calculateSetpointOrPidOutput(...)
+		clampedTarget = clamp(calculatedTarget, minInverterPower, maxInverterPower)
+		limitedSetpoint = applyAsymmetricRampLimit(
+		    clampedTarget,
+		    previousSetpoint,
+		    maxSetpointRiseWattsPerSecond,
+		    maxSetpointFallWattsPerSecond,
+		    deltaTimeSeconds
+		)
+		```
+	- Validation notes for later:
+		- verify that setpoint drops quickly when a large load switches off
+		- verify that setpoint rises gradually when load increases
+		- verify that short spikes do not immediately pull the inverter setpoint up
+		- verify that zero-feed-in behavior is improved or at least not degraded
+		- keep the logic non-blocking
+		- preserve existing PID / setpoint calculation behavior when both ramp settings are disabled or set high enough

--- a/examples/SolarInverterLimiter/platformio.ini
+++ b/examples/SolarInverterLimiter/platformio.ini
@@ -36,8 +36,8 @@ lib_deps =
 	adafruit/Adafruit BusIO@^1.17.4
 	bblanchon/ArduinoJson@7.4.3
 	esphome/ESPAsyncWebServer-esphome@^3.4.0
-	vitaly.ruhl/ESP32 Configuration Manager@^4.0.0
-	; C:\Daten\_Codding\ESP32\ConfigurationsManager
+	vitaly.ruhl/ESP32 Configuration Manager@^4.0.5
+	;symlink://C:/Daten/_Codding/ESP32/ConfigurationsManager
 test_ignore = src/main.cpp
 extra_scripts =
 	pre:./tools/precompile_wrapper.py
@@ -64,30 +64,17 @@ lib_deps =
 	adafruit/Adafruit BusIO@^1.17.4
 	bblanchon/ArduinoJson@7.4.3
 	esphome/ESPAsyncWebServer-esphome@^3.4.0
-	;vitaly.ruhl/ESP32 Configuration Manager@^4.0.4
+	;vitaly.ruhl/ESP32 Configuration Manager@^4.0.5
 	symlink://C:/Daten/_Codding/ESP32/ConfigurationsManager
 test_ignore = src/main.cpp
 extra_scripts =
 	pre:./tools/precompile_wrapper.py
-; OTA Einstellungen
 upload_protocol = espota
-;;solar-limiter-vivil
 upload_port = 192.168.2.122
-;upload_flags = --auth=ota1234 -t 120 -c 512
 
 upload_flags =
     -a
     otaSI
     -t
-    60
-
-;;test-esp
-;upload_port = 192.168.2.126
-;upload_flags = --auth=ota1234
-
-
-; -t 60   -> Timeout (Standard 10s) erhöht für instabile Netze
-; -c 1024 -> Kleinere Datenpakete (Standard ~1460) bei problematischem WLAN
-;upload_flags = --auth=ota1234 -t 60 -c 1024
-;upload_flags = --auth=ota1234 -t 120 -c 512
+    120
 

--- a/examples/SolarInverterLimiter/src/main.cpp
+++ b/examples/SolarInverterLimiter/src/main.cpp
@@ -58,8 +58,18 @@
 #endif
 
 #ifndef VERSION
-#define VERSION "4.1.2"
+#define VERSION "4.2.0"
 #endif
+
+#ifndef FEATURE_FAN_ENABLED
+#define FEATURE_FAN_ENABLED 0
+#endif
+
+#ifndef FEATURE_HEATER_ENABLED
+#define FEATURE_HEATER_ENABLED 0
+#endif
+
+#define FEATURE_ANY_RELAY_OUTPUTS (FEATURE_FAN_ENABLED || FEATURE_HEATER_ENABLED)
 
 enum class NegativePriceSettingPreference : uint8_t
 {
@@ -76,8 +86,12 @@ void readBme280();
 void WriteToDisplay();
 void SetupStartTemperatureMeasuring();
 void ProjectConfig();
+#if FEATURE_FAN_ENABLED
 void CheckVentilator(float currentTemperature);
+#endif
+#if FEATURE_HEATER_ENABLED
 void EvaluateHeater(float currentTemperature);
+#endif
 void ShowDisplayOn();
 void ShowDisplayOff();
 static void logNetworkIpInfo(const char *context);
@@ -103,11 +117,17 @@ static int computePidStabilizedTarget(int baseTarget, int configuredMin, int con
 static void updateMqttTopics();
 static void publishMqttNow();
 static void updateStatusLED();
+#if FEATURE_FAN_ENABLED
 static void setFanRelay(bool on);
-static void setHeaterRelay(bool on);
-static void setManualOverride(bool on);
 static bool getFanRelay();
+#endif
+#if FEATURE_HEATER_ENABLED
+static void setHeaterRelay(bool on);
 static bool getHeaterRelay();
+#endif
+#if FEATURE_ANY_RELAY_OUTPUTS
+static void setManualOverride(bool on);
+#endif
 //--------------------------------------------------------------------------------------------------------------
 
 #pragma region configuration variables
@@ -179,6 +199,7 @@ struct I2CSettings
     }
 };
 
+#if FEATURE_FAN_ENABLED
 struct FanSettings
 {
     Config<bool> enabled{ConfigOptions<bool>{.key = "FanEnable", .name = "Enable Fan Control", .category = "Fan", .defaultValue = false, .sortOrder = 1}};
@@ -192,7 +213,9 @@ struct FanSettings
         cfg.addSetting(&offThreshold);
     }
 };
+#endif
 
+#if FEATURE_HEATER_ENABLED
 struct HeaterSettings
 {
     Config<bool> enabled{ConfigOptions<bool>{.key = "HeatEnable", .name = "Enable Heater Control", .category = "Heater", .defaultValue = false, .sortOrder = 1}};
@@ -206,6 +229,7 @@ struct HeaterSettings
         cfg.addSetting(&offTemp);
     }
 };
+#endif
 
 struct DisplaySettings
 {
@@ -257,9 +281,13 @@ float Pressure = 0.0;       // current pressure in hPa
 bool displayActive = true; // flag to indicate if the display is active
 static bool displayInitialized = false;
 static bool bme280Initialized = false;
+#if FEATURE_HEATER_ENABLED
 static bool dewpointRiskActive = false;   // tracks dewpoint alarm state
 static bool heaterLatchedState = false;   // hysteresis latch for heater
+#endif
+#if FEATURE_ANY_RELAY_OUTPUTS
 static bool manualOverrideActive = false; // when enabled, buttons control relays and automation pauses
+#endif
 
 static const char GLOBAL_THEME_OVERRIDE[] PROGMEM = R"CSS(
 .rw[data-group="sensors"][data-key="temp"]{ color:rgb(198, 16, 16) !important; font-weight:900; font-size: 1.2rem; }
@@ -279,8 +307,12 @@ static cm::AlarmManager alarmManager;
 LimiterSettings limiterSettings;
 TempSettings tempSettings;
 I2CSettings i2cSettings;
+#if FEATURE_FAN_ENABLED
 FanSettings fanSettings;
+#endif
+#if FEATURE_HEATER_ENABLED
 HeaterSettings heaterSettings;
+#endif
 DisplaySettings displaySettings;
 WiFiRoamingSettings wifiRoamingSettings;
 RS485_Settings rs485settings;
@@ -291,8 +323,12 @@ static cm::CoreWiFiSettings &wifiSettings = coreSettings.wifi;
 static cm::CoreNtpSettings &ntpSettings = coreSettings.ntp;
 static cm::CoreWiFiServices wifiServices;
 
+#if FEATURE_FAN_ENABLED
 static constexpr char IO_FAN_ID[] = "fan_relay";
+#endif
+#if FEATURE_HEATER_ENABLED
 static constexpr char IO_HEATER_ID[] = "heater_relay";
+#endif
 static constexpr char IO_RESET_ID[] = "reset_btn";
 static constexpr char IO_AP_ID[] = "ap_btn";
 
@@ -382,8 +418,12 @@ void setup()
 
     RS485Ticker.attach(limiterSettings.RS232PublishPeriod.get(), cb_RS485Listener);
 
+#if FEATURE_FAN_ENABLED
     setFanRelay(false);
+#endif
+#if FEATURE_HEATER_ENABLED
     setHeaterRelay(false);
+#endif
 
     lmg.logTag(LL::Info, "SETUP", "Completed successfully. Starting main loop...");
 }
@@ -433,11 +473,17 @@ void loop()
 
     WriteToDisplay();
 
+#if FEATURE_ANY_RELAY_OUTPUTS
     if (!manualOverrideActive)
     {
+#if FEATURE_FAN_ENABLED
         CheckVentilator(temperature);
+#endif
+#if FEATURE_HEATER_ENABLED
         EvaluateHeater(temperature);
+#endif
     }
+#endif
     delay(10);
 }
 
@@ -451,10 +497,14 @@ void setupGUI()
     ConfigManager.addSettingsGroup("Temp", "Temp", "Temp Settings", 70);
     ConfigManager.addSettingsPage("I2C", 80);
     ConfigManager.addSettingsGroup("I2C", "I2C", "I2C Settings", 80);
+#if FEATURE_FAN_ENABLED
     ConfigManager.addSettingsPage("Fan", 90);
     ConfigManager.addSettingsGroup("Fan", "Fan", "Fan Settings", 90);
+#endif
+#if FEATURE_HEATER_ENABLED
     ConfigManager.addSettingsPage("Heater", 100);
     ConfigManager.addSettingsGroup("Heater", "Heater", "Heater Settings", 100);
+#endif
     ConfigManager.addSettingsPage("Display", 110);
     ConfigManager.addSettingsGroup("Display", "Display", "Display Settings", 110);
     ConfigManager.addSettingsPage("RS485", 120);
@@ -550,6 +600,7 @@ void setupGUI()
     // endregion Limiter
 
     // region relay outputs
+#if FEATURE_ANY_RELAY_OUTPUTS
     auto outputs = ConfigManager.liveGroup("Outputs")
                        .page("Limiter", 30)
                        .card("Outputs", 30)
@@ -564,6 +615,7 @@ void setupGUI()
                { setManualOverride(on); })
         .order(0);
 
+#if FEATURE_FAN_ENABLED
     outputs.stateButton(
                "ventilator",
                "Ventilator Relay Active",
@@ -575,7 +627,9 @@ void setupGUI()
                "On",
                "Off")
         .order(1);
+#endif
 
+#if FEATURE_HEATER_ENABLED
     outputs.stateButton(
                "heater",
                "Heater Relay Active",
@@ -613,6 +667,8 @@ void setupGUI()
               dewpointRiskActive = false;
               lmg.logTag(LL::Info, "ALARM", "Dewpoint risk EXIT");
               EvaluateHeater(temperature); });
+#endif
+#endif
     // endregion relay outputs
 }
 
@@ -664,11 +720,15 @@ static void registerIOBindings()
     lmg.scopedTag("IO");
     analogReadResolution(12);
 
+#if FEATURE_FAN_ENABLED
     ioManager.addDigitalOutput(IO_FAN_ID, "Cooling Fan Relay", 23, true, true);
     ioManager.addDigitalOutputToSettingsGroup(IO_FAN_ID, "I/O", "Cooling Fan Relay", "Cooling Fan Relay", 1);
+#endif
 
+#if FEATURE_HEATER_ENABLED
     ioManager.addDigitalOutput(IO_HEATER_ID, "Heater Relay", 27, true, true);
     ioManager.addDigitalOutputToSettingsGroup(IO_HEATER_ID, "I/O", "Heater Relay", "Heater Relay", 2);
+#endif
 
     ioManager.addDigitalInput(IO_RESET_ID, "Reset Button", 14, true, true, false, true);
     ioManager.addDigitalInputToSettingsGroup(IO_RESET_ID, "I/O", "Reset Button", "Reset Button", 10);
@@ -810,8 +870,12 @@ static void registerProjectSettings()
     limiterSettings.attachTo(ConfigManager);
     tempSettings.attachTo(ConfigManager);
     i2cSettings.attachTo(ConfigManager);
+#if FEATURE_FAN_ENABLED
     fanSettings.attachTo(ConfigManager);
+#endif
+#if FEATURE_HEATER_ENABLED
     heaterSettings.attachTo(ConfigManager);
+#endif
     displaySettings.attachTo(ConfigManager);
     wifiRoamingSettings.attachTo(ConfigManager);
     rs485settings.attachTo(ConfigManager);
@@ -1183,6 +1247,7 @@ static int computePidStabilizedTarget(int baseTarget, int configuredMin, int con
     return static_cast<int>(roundf(pidController.output));
 }
 
+#if FEATURE_FAN_ENABLED
 static void setFanRelay(bool on)
 {
     if (!fanSettings.enabled.get())
@@ -1192,34 +1257,47 @@ static void setFanRelay(bool on)
     ioManager.setState(IO_FAN_ID, on);
 }
 
+static bool getFanRelay()
+{
+    return ioManager.getState(IO_FAN_ID);
+}
+#endif
+
+#if FEATURE_HEATER_ENABLED
 static void setHeaterRelay(bool on)
 {
-    if (!heaterSettings.enabled.get() && !manualOverrideActive)
+    if (!heaterSettings.enabled.get()
+#if FEATURE_ANY_RELAY_OUTPUTS
+        && !manualOverrideActive
+#endif
+    )
     {
         on = false;
     }
     ioManager.setState(IO_HEATER_ID, on);
 }
 
+static bool getHeaterRelay()
+{
+    return ioManager.getState(IO_HEATER_ID);
+}
+#endif
+
+#if FEATURE_ANY_RELAY_OUTPUTS
 static void setManualOverride(bool on)
 {
     manualOverrideActive = on;
     if (!manualOverrideActive)
     {
+#if FEATURE_FAN_ENABLED
         CheckVentilator(temperature);
+#endif
+#if FEATURE_HEATER_ENABLED
         EvaluateHeater(temperature);
+#endif
     }
 }
-
-static bool getFanRelay()
-{
-    return ioManager.getState(IO_FAN_ID);
-}
-
-static bool getHeaterRelay()
-{
-    return ioManager.getState(IO_HEATER_ID);
-}
+#endif
 
 //----------------------------------------
 // MQTT FUNCTIONS
@@ -1563,12 +1641,15 @@ void WriteToDisplay()
     display.display();
 }
 
+#if FEATURE_FAN_ENABLED
 void CheckVentilator(float currentTemperature)
 {
+#if FEATURE_ANY_RELAY_OUTPUTS
     if (manualOverrideActive)
     {
         return;
     }
+#endif
     if (!fanSettings.enabled.get())
     {
         setFanRelay(false);
@@ -1583,14 +1664,18 @@ void CheckVentilator(float currentTemperature)
         setFanRelay(false);
     }
 }
+#endif
 
+#if FEATURE_HEATER_ENABLED
 void EvaluateHeater(float currentTemperature)
 {
 
+#if FEATURE_ANY_RELAY_OUTPUTS
     if (manualOverrideActive)
     {
         return;
     }
+#endif
 
     if (dewpointRiskActive)
     {
@@ -1616,6 +1701,7 @@ void EvaluateHeater(float currentTemperature)
     }
     setHeaterRelay(heaterLatchedState);
 }
+#endif
 
 void ShowDisplayOn()
 {

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32 Configuration Manager",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "keywords": "esp32, configuration, wifi, web-server, ota, iot, automation",
   "description": "Robust configuration management system with web interface for ESP32 and ota support.",
   "repository": {

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -44,7 +44,7 @@ public:
 };
 #endif
 
-#define CONFIGMANAGER_VERSION "4.0.5" // Synced to library.json
+#define CONFIGMANAGER_VERSION "4.0.6" // Synced to library.json
 
 #if CM_ENABLE_THEMING && CM_ENABLE_STYLE_RULES
 inline constexpr char CM_DEFAULT_RUNTIME_STYLE_CSS[] PROGMEM = R"CSS(

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "esp32-config-webui",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "esp32-config-webui",
-      "version": "4.0.5",
+      "version": "4.0.6",
       "dependencies": {
         "vue": "^3.5.34"
       },

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esp32-config-webui",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Update SolarInverterLimiter to use ConfigurationsManager 4.0.5 in the published USB environment
- Gate fan and heater relay output code behind compile-time feature flags to reduce default firmware size
- Bump ConfigurationsManager package/WebUI version to 4.0.6 and document the example update

## Validation
- pio run -e usb
- pio run -e usb (examples/SolarInverterLimiter)