### PR TITLE
Improve PlatformIO discoverability for config-related searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # ConfigurationsManager for ESP32
 
-> Version 4.0.0
+> Version 4.1.1
+
+## Preview Before Installing
+
+If you want to quickly evaluate coding style and project structure before installing,
+check the standalone examples in [examples/](examples/).
+
+Recommended first look:
+
+- [examples/minimal](examples/minimal)
+- [examples/Full-GUI-Demo](examples/Full-GUI-Demo)
+- [examples/Full-IO-Demo](examples/Full-IO-Demo)
 
 ## Why this exists
 
@@ -12,7 +23,7 @@ But together they quickly turn into repetitive boilerplate that distracts from t
 
 This library exists to solve that once.
 
-It provides a structured, type-safe way to define settings, persist them, expose them through a responsive Web UI, and interact with live runtime data — without forcing you to design yet another custom web server or configuration layer.
+It provides a structured, type-safe way to define config/settings, persist them, expose them through a responsive Web UI, and interact with live runtime data — without forcing you to design yet another custom web server or configuration layer.
 
 You focus on your application logic.
 The infrastructure is already there.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog is a curated overview.
 
+## 4.1.1
+
+- Expanded PlatformIO library metadata keywords for config-related discovery, including `config`, `config-manager`, `settings`, `wi-fi`, and `nvs` variants.
+- Updated package description wording to include both "config" and "configuration" search intents.
+- WebUI package version aligned with the ConfigurationsManager package/library version at 4.1.1.
+
 ## 4.1.0
 
 - Added lazy MQTT extra-topic publish helpers so payload callbacks run only after

--- a/library.json
+++ b/library.json
@@ -1,8 +1,8 @@
 {
   "name": "ESP32 Configuration Manager",
-  "version": "4.1.0",
-  "keywords": "esp32, configuration, wifi, web-server, ota, iot, automation",
-  "description": "Robust configuration management system with web interface for ESP32 and ota support.",
+  "version": "4.1.1",
+  "keywords": "esp32, configuration, configurations, config, config-manager, configuration-manager, settings, settings-manager, wifi, wi-fi, web-server, web-ui, ota, nvs, preferences, iot, automation",
+  "description": "Robust ESP32 config and configuration manager with web UI, WiFi setup, OTA, and persistent settings via NVS/Preferences.",
   "repository": {
     "type": "git",
     "url": "https://github.com/vitalyruhl/ConfigurationsManager.git"

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esp32-config-webui",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary\n- expand library.json keywords for config/configuration/settings/wifi variants\n- improve package description wording for config-related search intent\n- add a top README preview section linking to key examples before installation\n- align package versions to 4.1.1 and document the metadata update in changelog\n\n## Validation\n- no C++ source/header files changed\n- PlatformIO build intentionally skipped per repository policy for non-CPP/non-H changes\n\n## Notes\n- this change is focused on registry discoverability and documentation UX only