### PR TITLE
chore: update governance version-sync notes and README version

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -319,6 +319,7 @@ reported before any further action.
   - `src/ConfigManager.h`
   - `webui/package.json`
   - `webui/package-lock.json`
+  - README version badges or project/library version mentions, when present
   - minimal example version references, including
     `examples/minimal/platformio.ini`, `examples/minimal/src/main.cpp`, and any
     other minimal example file containing the library/app version

--- a/.github/agents/refactor.agent.md
+++ b/.github/agents/refactor.agent.md
@@ -75,9 +75,10 @@ Use this agent for:
   truth.
 - When the project/library version changes, synchronize the known mirror paths:
   `library.json`, `src/ConfigManager.h`, `webui/package.json`,
-  `webui/package-lock.json`, `examples/minimal/platformio.ini`,
-  `examples/minimal/src/main.cpp`, and any other minimal example file containing
-  the library/app version. Report any missing listed path.
+  `webui/package-lock.json`, README version badges or project/library version
+  mentions, `examples/minimal/platformio.ini`, `examples/minimal/src/main.cpp`,
+  and any other minimal example file containing the library/app version. Report
+  any missing listed path.
 - Keep the minimal example aligned with the ConfigurationsManager
   project/library version. Do not automatically change other examples'
   firmware/application versions unless the issue explicitly asks for it.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ConfigurationsManager for ESP32
 
-> Version 4.1.1
+> Version 4.2.0
 
 ## Preview Before Installing
 


### PR DESCRIPTION
## Summary\n- add README version mentions to governance version-sync mirror paths\n- align refactor-agent version-sync guidance with README mentions\n- update README displayed version to 4.2.0\n\n## Validation\n- skipped build: no .cpp/.h changes