### PR TITLE
Configure Serena project memories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,16 @@ secrets.h
 /webui/dist/index.html
 /tools/_buildlogs
 .pio-home
+
+# Serena local/cache data
+/.cache/
+/.serena/project.local.yml
+/.serena/cache/
+/.serena/logs/
+/.serena/index/
+/.serena/compile_commands.json
+/.serena/memories/local/
+/.serena/memories/tmp/
+/.serena/memories/local_*.md
+/.serena/memories/tmp_*.md
+/compile_commands.json

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,9 @@
+/cache/
+/logs/
+/index/
+/project.local.yml
+/compile_commands.json
+/memories/local/
+/memories/tmp/
+/memories/local_*.md
+/memories/tmp_*.md

--- a/.serena/memories/core.md
+++ b/.serena/memories/core.md
@@ -1,0 +1,12 @@
+# ConfigurationsManager Memory Index
+
+- Repository governance is canonical; Serena memories only summarize it.
+- Read `mem:shared/governance_index` before changing files or running workflows.
+- Read `mem:shared/project_overview` and `mem:shared/architecture` for project orientation.
+- Read `mem:shared/build_and_test_commands` before validation.
+- Read `mem:shared/esp32_platformio_notes` and `mem:shared/known_pitfalls` before C++,
+  PlatformIO, WebUI, hardware-facing, or configuration-sensitive work.
+- Read `mem:shared/release_rules` before version, changelog, release, or integration work.
+- Read `mem:shared/agent_workflow_notes` before invoking repository workflow shortcuts.
+- Put machine-specific, private, or temporary notes under `local/` or `tmp/`; those topics
+  must never be copied into shared memories and are ignored by Git.

--- a/.serena/memories/shared/agent_workflow_notes.md
+++ b/.serena/memories/shared/agent_workflow_notes.md
@@ -1,0 +1,20 @@
+# Agent Workflow Notes
+
+- Status: canonical summary; always reread `.github/AGENTS.md` and the applicable agent
+  file before acting.
+- `workflow.begin`: create/select the appropriate side branch, then stop before edits.
+- `workflow.checkpoint`: commit and push the current coherent state.
+- `workflow.docs`: perform narrow documentation synchronization.
+- `workflow.audit`: strictly read-only; no file, branch, commit, or merge changes.
+- `workflow.ship`: build and verify artifacts without implicit merge.
+- `workflow.ready`: prepare for review/integration and run or report validation; do not
+  merge or update release branches.
+- `workflow.toMain`: use the agreed integration workflow, normally a PR; validation and
+  documentation impact checks are required before merge.
+- `workflow.cleanBranches`: delete only branches verified as integrated.
+- `workflow.end`: report repository, validation, and blocker state without implicit Git
+  writes.
+- Shortcuts run sequentially. Follow-up work after `workflow.audit` requires explicit user
+  request and no remaining blockers.
+
+Sources: `.github/AGENTS.md`, `.github/agents/workflow.agent.md`.

--- a/.serena/memories/shared/architecture.md
+++ b/.serena/memories/shared/architecture.md
@@ -1,0 +1,24 @@
+# Architecture
+
+- Status: verified.
+- `ConfigManagerClass` in `src/ConfigManager.h` is the central class for settings,
+  persistence, WiFi, web, OTA, and runtime modules.
+- `Config<T>`, `ConfigOptions<T>`, and `BaseSetting` define typed settings and persistence
+  behavior.
+- Main modules:
+  - `src/wifi/`: connection lifecycle, recovery, AP mode, and smart roaming.
+  - `src/web/`: AsyncWebServer routes, request handling, and WebUI/API integration.
+  - `src/ota/`: OTA state and upload handling.
+  - `src/runtime/`: live values, metadata, controls, styling, and WebSocket payloads.
+  - `src/io/`, `src/alarm/`, `src/logging/`, `src/mqtt/`: optional application helpers.
+  - `src/core/`: reusable core settings and WiFi service composition.
+- `ConfigManagerClass` contains `ConfigManagerWiFi`, `ConfigManagerWeb`,
+  `ConfigManagerOTA`, and `ConfigManagerRuntime`.
+- No `WebConfig` or `Webconfig` type exists; the web class is `ConfigManagerWeb`.
+- Public headers live under `src/`; this repository has no `include/` directory.
+- `webui/` builds the Vue application. `tools/webui_to_header.js` converts WebUI build
+  output into checked-in `src/html_content.h`; `src/html_content.cpp` is the wrapper.
+
+Sources: `src/ConfigManager.h`, `src/core/`, `src/wifi/`, `src/web/`, `src/ota/`,
+`src/runtime/`, `src/io/`, `src/alarm/`, `src/logging/`, `src/mqtt/`,
+`tools/webui_to_header.js`.

--- a/.serena/memories/shared/build_and_test_commands.md
+++ b/.serena/memories/shared/build_and_test_commands.md
@@ -1,0 +1,27 @@
+# Build And Test Commands
+
+- Status: commands below are verified from repository configuration, documentation, or
+  canonical governance.
+- Required default validation after C++ source/header changes:
+  `pio run -e usb`
+- Build the minimal example:
+  `pio run -d examples/minimal -e usb`
+- Build the documented BME280 example:
+  `pio run -d examples/BME280-Temp-Sensor -e usb`
+- Clean the selected PlatformIO project:
+  `pio run -t clean`
+- Canonical governance requires relevant tests when tests are affected, but the repository
+  currently documents no verified concrete test environment. Do not treat the stale
+  `test` or `nodemcu-32s` test-environment references as runnable facts.
+- WebUI development commands run from `webui/`: `npm install`, `npm run dev`, and
+  `npm run build`.
+- Regenerate embedded WebUI output from the repository root only when WebUI output is in
+  scope: `node tools/webui_to_header.js`.
+- Upload, monitor, erase, and OTA commands are not validation defaults and require explicit
+  user approval.
+- No enabled GitHub Actions workflow exists; `.github/workflows/pio-tests.yml.deactivate`
+  is deactivated.
+
+Sources: `.github/AGENTS.md`, `platformio.ini`, `README.md`, `docs/GETTING_STARTED.md`,
+`webui/README.md`, `webui/package.json`, `.github/workflows/pio-tests.yml.deactivate`,
+`test/README`.

--- a/.serena/memories/shared/esp32_platformio_notes.md
+++ b/.serena/memories/shared/esp32_platformio_notes.md
@@ -1,0 +1,24 @@
+# ESP32 And PlatformIO Notes
+
+- Status: verified.
+- C++17 is required. Root and example PlatformIO configurations remove GNU++11 and add
+  `-std=gnu++17`.
+- The root environment is `usb`, using `platform = espressif32`, `board = nodemcu-32s`,
+  and `framework = arduino`.
+- Example environment names are `usb`, `ota`, `ota_no_oled`, and
+  `ota_no_oled_no_bme`; the last two occur only in SolarInverterLimiter.
+- SolarInverterLimiter pins `platformio/espressif32@7.0.1`; the root and other audited
+  examples use unpinned `espressif32`.
+- Core dependencies are ArduinoJson, ESPAsyncWebServer-esphome, and AsyncTCP-esphome.
+  MQTT examples additionally use PubSubClient.
+- Most examples keep `build_dir` and `libdeps_dir` outside the repository to avoid recursive
+  local-library installs. Several examples consume this repository through `../..` and use
+  `tools/pio_force_local_lib_refresh.py`.
+- If an example appears to use stale local library code, clean and rebuild the example.
+  `CM_PIO_NO_LIB_REFRESH=1` disables the forced local refresh helper.
+- Secrets, local WiFi details, serial ports, OTA addresses, and credentials are local data;
+  never put them in shared Serena memories.
+- Feature flags and their defaults are documented in `docs/FEATURE_FLAGS.md`.
+
+Sources: `platformio.ini`, `examples/**/platformio.ini`, `library.json`,
+`docs/GETTING_STARTED.md`, `docs/FEATURE_FLAGS.md`.

--- a/.serena/memories/shared/governance_index.md
+++ b/.serena/memories/shared/governance_index.md
@@ -1,0 +1,20 @@
+# Governance Index
+
+- Status: canonical summary; always reread the source governance files.
+- Always reread `.github/AGENTS.md`; it is canonical and overrides summaries.
+- Read the applicable agent file directly:
+  - `.github/agents/refactor.agent.md` for code, tests, build, and structural changes.
+  - `.github/agents/docs.agent.md` for documentation.
+  - `.github/agents/workflow.agent.md` for branches, commits, PRs, merges, releases, and
+    cleanup.
+- Normal user chat is informal German. Repository artifacts, code comments, logs, commit
+  messages, issues, PRs, and governance text are English.
+- User changes are sacred. Analyze before editing and never revert unrelated changes.
+- Do not edit `main` or `master`; use one side branch. Git writes require explicit user
+  approval or an explicitly requested governed workflow.
+- Upload, monitor, erase, OTA, and hardware/network-affecting commands require explicit
+  user approval.
+- Do not mark an issue solved or fixed until the user confirms it works.
+
+Sources: `AGENTS.md`, `.github/AGENTS.md`, `.github/agents/refactor.agent.md`,
+`.github/agents/docs.agent.md`, `.github/agents/workflow.agent.md`.

--- a/.serena/memories/shared/known_pitfalls.md
+++ b/.serena/memories/shared/known_pitfalls.md
@@ -1,0 +1,32 @@
+# Known Pitfalls
+
+- Status: verified facts and canonical risk rules.
+- Settings structure, storage keys, and NVS layout are compatibility-sensitive under
+  canonical governance.
+- The WebUI and API use plain HTTP. Passwords are masked in the UI but transmitted over
+  HTTP in cleartext and stored in plaintext in ESP32 NVS/Preferences.
+- `src/html_content.h` is generated from `webui/dist/` and checked in. `webui/dist/` and
+  PlatformIO output directories are generated and ignored.
+- Examples may have independent firmware/application versions and machine-specific build or
+  upload settings. Inspect the affected example before changing it.
+- PlatformIO local dependency caches can make example builds appear stale; clean/rebuild
+  before diagnosing source behavior.
+- On classic ESP32, ADC2 pins are typically unavailable to `analogRead()` while WiFi is
+  active.
+- MQTT publishing through PubSubClient supports QoS 0 only.
+- SolarInverterLimiter is documented as close to the flash limit.
+- Verified documentation/tooling drift:
+  - README project version is `4.2.0`, while canonical `library.json` is `4.2.1`.
+  - `docs/CONTRIBUTING.md` references missing `docs/NAMING.md`.
+  - Disabled CI and `test/README` reference test environments absent from PlatformIO config.
+  - `docs/SETTINGS.md` describes truncated keys, while current source stores hashed keys.
+  - `tools/publish.py` expects README changelog entries, but README points to
+    `docs/CHANGELOG.md`.
+- Code/log output must use English, ASCII, and short severity tags `[E]`, `[W]`, `[I]`,
+  `[D]`, or `[T]`.
+
+Sources: `.github/AGENTS.md`, `.gitignore`, `README.md`, `library.json`,
+`src/ConfigManager.h`, `tools/webui_to_header.js`, `tools/publish.py`,
+`docs/SECURITY.md`, `docs/WIFI.md`, `docs/MQTT.md`, `docs/CHANGELOG.md`,
+`docs/SETTINGS.md`, `docs/CONTRIBUTING.md`, `.github/workflows/pio-tests.yml.deactivate`,
+`test/README`.

--- a/.serena/memories/shared/project_overview.md
+++ b/.serena/memories/shared/project_overview.md
@@ -1,0 +1,21 @@
+# Project Overview
+
+- Status: verified unless marked canonical.
+- ConfigurationsManager is a C++17 Arduino/ESP32 library and example firmware built with
+  PlatformIO.
+- Verified features include typed settings, ESP32 Preferences/NVS persistence, JSON
+  configuration, an embedded web UI, runtime values, WebSocket updates, WiFi management,
+  OTA, and optional MQTT, logging, alarm, and IO helpers.
+- `library.json` is the canonical package/library metadata and version source.
+- Main areas:
+  - `src/`: library source and checked-in embedded WebUI output.
+  - `examples/`: standalone PlatformIO example applications.
+  - `webui/`: Vue 3 WebUI sources and npm tooling.
+  - `docs/`: user and contributor documentation.
+  - `test/`: PlatformIO tests.
+  - `tools/`: build, validation, WebUI embedding, and release helpers.
+- `README.md` is the public entry point. `.github/AGENTS.md` is canonical agent governance.
+- Serena project indexing is configured for `cpp`.
+
+Sources: `README.md`, `library.json`, `platformio.ini`, `src/ConfigManager.h`,
+`webui/package.json`, `.serena/project.yml`.

--- a/.serena/memories/shared/release_rules.md
+++ b/.serena/memories/shared/release_rules.md
@@ -1,0 +1,26 @@
+# Release And Version Rules
+
+- Status: canonical summary; reread governance before release or version work.
+- Always reread `.github/AGENTS.md` and `.github/agents/workflow.agent.md` before version,
+  release, or integration work.
+- `library.json` is the only canonical ConfigurationsManager project/library version source.
+  Known mirrors must be scanned and synchronized when that version changes.
+- Examples other than the minimal example may have independent app/firmware versions; do
+  not change them automatically.
+- Version, dependency, PlatformIO, firmware, and build-output changes follow the repository
+  version policy. Governance-only and documentation-only changes do not require a version
+  bump.
+- User-visible, release-relevant, dependency, build, or version changes require a changelog
+  decision and documentation impact check.
+- `main` is published/released and receives changes through PRs by default. `release/*`
+  branches are runnable snapshots; do not assume one exists.
+- Never stage, commit, push, merge, create/update release branches, or clean branches unless
+  explicitly requested or covered by a named governed workflow.
+- No rule requires a patch bump merely when `workflow.begin` or refactor work starts.
+- Current verified version state: canonical `library.json`, `src/ConfigManager.h`,
+  `webui/package.json`, and `webui/package-lock.json` are `4.2.1`; README still says
+  `4.2.0`.
+
+Sources: `.github/AGENTS.md`, `.github/agents/workflow.agent.md`,
+`.github/agents/refactor.agent.md`, `library.json`, `src/ConfigManager.h`,
+`webui/package.json`, `webui/package-lock.json`, `README.md`.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,180 @@
+# the name by which the project can be referenced within Serena
+project_name: "ConfigurationsManager"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- cpp
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend: LSP
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths:
+- ".git/**"
+- ".cache/**"
+- ".pio/**"
+- ".pio-build/**"
+- ".pioenvs/**"
+- ".piolibdeps/**"
+- ".vscode/**"
+- ".idea/**"
+- "build/**"
+- "dist/**"
+- "coverage/**"
+- ".pytest_cache/**"
+- "node_modules/**"
+- "docs/generated/**"
+- "src/secret/**"
+- "dev-info/secret/**"
+- "examples/**/.pio/**"
+- "examples/**/build/**"
+- "examples/**/dist/**"
+- "examples/**/node_modules/**"
+- "examples/**/src/secret/**"
+- "libdeps/**"
+- "webui/dist/**"
+- "webui/node_modules/**"
+- ".serena/cache/**"
+- ".serena/logs/**"
+- ".serena/index/**"
+- ".serena/compile_commands.json"
+- ".serena/memories/local/**"
+- ".serena/memories/tmp/**"
+- ".serena/memories/local_*.md"
+- ".serena/memories/tmp_*.md"
+- "compile_commands.json"
+- "*.bin"
+- "*.elf"
+- "*.map"
+- "*.hex"
+- "*.zip"
+- "*.7z"
+- "*.log"
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: true
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: >-
+  Repository governance is canonical. Before repository work, read
+  .github/AGENTS.md and the applicable .github/agents/*.agent.md file directly.
+  Serena memories are curated summaries only. Preserve user changes, do not
+  modify main or master, and do not run upload, monitor, erase, or other
+  hardware/network-affecting commands without explicit user approval.
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns:
+- "core"
+- "shared/.*"
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []


### PR DESCRIPTION
## Summary
- add a read-only Serena C++/LSP project configuration
- add curated shared project, architecture, governance, build, platform, pitfall, release, and workflow memories
- keep Serena local, cache, log, index, temporary, and generated data untracked

## Validation
- Serena 1.5.3 project health check passed
- Serena memory reference check passed
- practical symbol overview, symbol search, pattern search, and memory query passed
- Git ignore and private-data checks passed

## Documentation and version impact
- no project documentation sync required; these are curated Serena context files
- no changelog entry required
- no version bump required
- PlatformIO build skipped because no C++ or header files changed