### PR TITLE
docs: align README version with 4.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ConfigurationsManager for ESP32
 
-> Version 4.2.0
+> Version 4.2.2
 
 ## Preview Before Installing
 


### PR DESCRIPTION
Aligns the README version marker with the canonical 4.2.2 release version.\n\nValidation:\n- npm ci\n- npm run build\n- pio run -e usb\n- pio pkg pack\n- release archive content inspection\n\nNo additional version bump is required because this only synchronizes an existing version mirror.