### PR TITLE
Add WT32 Ethernet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ConfigurationsManager for ESP32
 
-> Version 4.3.0
+> Version 4.4.0
 
 ## Preview Before Installing
 
@@ -82,6 +82,7 @@ ConfigurationsManager is a C++17 helper library and example firmware for ESP32 p
 | ----------------------------------------- | ------------------------------------------------------ |
 | Getting Started (minimal pattern)         | [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md)     |
 | WiFi (DHCP/static/AP/reconnect)           | [docs/WIFI.md](docs/WIFI.md)                           |
+| Ethernet / external-network startup       | [docs/ETHERNET.md](docs/ETHERNET.md)                   |
 | Settings & OptionGroup                    | [docs/SETTINGS.md](docs/SETTINGS.md)                   |
 | GUI Runtime (Live + Styling + Theming)    | [docs/GUI-Runtime.md](docs/GUI-Runtime.md)             |
 | Logging                                   | [docs/LOGGING.md](docs/LOGGING.md)                     |
@@ -207,20 +208,21 @@ pio run -d examples/BME280-Temp-Sensor -e usb -t upload --upload-port COM5
 
 If you use a fork / local clone of this repo, you can build and upload any example the same way (the `-d examples/<name>` flag points PlatformIO to the example project directory).
 
-If you want to consume the library as a local dependency in your own project, you can also use a local `lib_deps = file://../ConfigurationsManager` setup (see the note about recursive local installs below).
+If you want to consume the library as a local dependency in your own project, use a local `lib_deps = symlink://../ConfigurationsManager` setup.
 
-Note (Windows): these example projects set `[platformio] build_dir` and `libdeps_dir` outside the repo to prevent recursive local installs when using `lib_deps = file://../..`.
+Note (Windows): these example projects set `[platformio] build_dir` and `libdeps_dir` outside the repo to prevent recursive local installs when using `lib_deps = symlink://../..`.
 
 Tips:
 
 - Avoid `lib_extra_dirs = ../..` for the workspace library; it can cause cross-example compilation issues.
-- Some examples include a pre-build helper script `tools/pio_force_local_lib_refresh.py` to force PlatformIO to refresh the local `file://../..` library copy automatically (disable via `CM_PIO_NO_LIB_REFRESH=1`).
+- Some examples include `tools/pio_force_local_lib_refresh.py` to refresh local library metadata before a build (disable via `CM_PIO_NO_LIB_REFRESH=1`).
 - If you see `UnicodeEncodeError: 'charmap' codec can't encode character ...` on Windows, see `docs/TROUBLESHOOTING.md`.
 
 More:
 
 - Getting started (full minimal pattern): `docs/GETTING_STARTED.md`
 - WiFi behavior / best practices: `docs/WIFI.md`
+- Ethernet / WT32-ETH01: `docs/ETHERNET.md`
 - OTA and Web UI flashing: `docs/OTA.md`
 - Troubleshooting: `docs/TROUBLESHOOTING.md`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ConfigurationsManager for ESP32
 
-> Version 4.2.3
+> Version 4.3.0
 
 ## Preview Before Installing
 
@@ -10,6 +10,7 @@ check the standalone examples in [examples/](examples/).
 Recommended first look:
 
 - [examples/minimal](examples/minimal)
+- [examples/WT32-ETH01-v1.4](examples/WT32-ETH01-v1.4)
 - [examples/Full-GUI-Demo](examples/Full-GUI-Demo)
 - [examples/Full-IO-Demo](examples/Full-IO-Demo)
 
@@ -62,7 +63,8 @@ ConfigurationsManager is a C++17 helper library and example firmware for ESP32 p
 - Per-setting styling & theming
 
 ### Device & Connectivity
-- WiFi helpers (DHCP / static / AP fallback)
+- Optional WiFi helpers (DHCP / static / AP fallback)
+- External-network startup for Ethernet-based projects
 - OTA firmware upload via WebUI
 - Optional MQTT module (PubSubClient-based)
 
@@ -181,6 +183,7 @@ Details: see `docs/SECURITY.md`.
 Each example is a standalone PlatformIO project:
 
 - [examples/minimal](examples/minimal) - minimal demo
+- [examples/WT32-ETH01-v1.4](examples/WT32-ETH01-v1.4) - WT32-ETH01 V1.4 Ethernet demo
 - [examples/BME280-Temp-Sensor](examples/BME280-Temp-Sensor) - BME280 temp sensor
 - [examples/Full-Logging-Demo](examples/Full-Logging-Demo) - logging and runtime log output demo
 - [examples/Full-MQTT-Demo](examples/Full-MQTT-Demo) - MQTT integration demo

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 This changelog is a curated overview.
 
+## 4.3.0
+
+- Added `CM_ENABLE_WIFI=0` to compile out ConfigManager WiFi connection, AP,
+  roaming, captive-portal, and WiFi runtime paths.
+- Added `ConfigManager.startWebServerOnNetwork()` for Ethernet and other
+  externally managed IP interfaces.
+- Removed the WiFi station status requirement from OTA initialization so OTA
+  can operate over Ethernet.
+- Added the `WT32-ETH01-v1.4` example with static Ethernet address
+  `192.168.2.127/24`, COM6 serial upload, Ethernet OTA, and a `noota` build.
+- WebUI package version aligned with the ConfigurationsManager package/library
+  version at 4.3.0.
+
 ## 4.2.3
 
 - Updated WebUI dependencies to `vue` 3.5.38 and `vite` 8.0.16.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 This changelog is a curated overview.
 
-## 4.3.0
+## 4.4.0
 
+- Added persisted Ethernet IP, subnet, gateway, and DNS settings to the
+  `WT32-ETH01-v1.4` example.
+- Added Settings password, OTA password, and NTP settings to the WT32 WebUI.
+- Added first-run initialization from an optional local `secrets.h` file.
 - Added `CM_ENABLE_WIFI=0` to compile out ConfigManager WiFi connection, AP,
   roaming, captive-portal, and WiFi runtime paths.
 - Added `ConfigManager.startWebServerOnNetwork()` for Ethernet and other
@@ -12,8 +16,9 @@ This changelog is a curated overview.
   can operate over Ethernet.
 - Added the `WT32-ETH01-v1.4` example with static Ethernet address
   `192.168.2.127/24`, COM6 serial upload, Ethernet OTA, and a `noota` build.
+- Updated the SolarInverterLimiter `espota` authentication value.
 - WebUI package version aligned with the ConfigurationsManager package/library
-  version at 4.3.0.
+  version at 4.4.0.
 
 ## 4.2.3
 

--- a/docs/ETHERNET.md
+++ b/docs/ETHERNET.md
@@ -1,0 +1,140 @@
+# Ethernet
+
+ConfigurationsManager can run on an IP interface initialized by the sketch.
+The library-managed WiFi connection, access-point, captive-portal, and roaming
+code can be removed with `CM_ENABLE_WIFI=0` while the WebUI and OTA remain
+available over Ethernet.
+
+The complete hardware example is
+[`examples/WT32-ETH01-v1.4`](../examples/WT32-ETH01-v1.4).
+
+## PlatformIO configuration
+
+Use the PlatformIO board definition and disable ConfigManager WiFi support in
+the common environment so USB, OTA, and no-OTA builds inherit it:
+
+```ini
+[env]
+platform = espressif32
+board = wt32-eth01
+framework = arduino
+build_flags =
+    -std=gnu++17
+    -DCM_ENABLE_WIFI=0
+
+[env:usb]
+upload_protocol = esptool
+upload_port = COM6
+
+[env:ota]
+upload_protocol = espota
+upload_port = 192.168.2.127
+upload_flags = --auth=ota-password
+
+[env:noota]
+board_build.partitions = no_ota.csv
+build_flags =
+    ${env.build_flags}
+    -DCM_ENABLE_OTA=0
+```
+
+Keep the authentication value synchronized with the OTA password used by the
+firmware. `-a ota-password` is equivalent to `--auth=ota-password`. An optional
+`-t 30` pair sets the `espota` timeout to 30 seconds; do not specify both
+authentication forms in the same environment.
+
+## Startup sequence
+
+The sketch owns Ethernet initialization and static/DHCP configuration. Start
+ConfigurationsManager services only after the interface has an IP address:
+
+```cpp
+if (ethernetHasIp && !networkServicesStarted)
+{
+    ConfigManager.startWebServerOnNetwork();
+#if CM_ENABLE_OTA
+    ConfigManager.setupOTA(APP_NAME, otaPassword);
+#endif
+    networkServicesStarted = true;
+}
+```
+
+Call `ConfigManager.handleClient()` regularly from `loop()`.
+
+`startWebServerOnNetwork()` initializes the WebUI, runtime provider, WebSocket,
+HTTP OTA routes, and other ConfigManager network services. It does not start or
+configure Ethernet itself.
+
+## WT32 persisted settings
+
+The WT32 example registers these values in NVS and exposes them in the WebUI:
+
+- Ethernet IP address
+- subnet mask
+- gateway
+- primary DNS server
+- Settings password
+- OTA enable state and OTA password
+- NTP servers, interval, and POSIX timezone
+
+Ethernet address changes take effect after a reboot. NTP is initialized after
+Ethernet receives its IP address. The NTP interval field is persisted for
+settings compatibility; the Ethernet example calls `configTzTime()` once and
+then uses the ESP32 SNTP client's internal resynchronization schedule.
+
+## First-run defaults
+
+Copy the tracked template and edit the local file:
+
+```powershell
+Copy-Item examples/WT32-ETH01-v1.4/src/secret/secrets.example.h `
+          examples/WT32-ETH01-v1.4/src/secret/secrets.h
+```
+
+`secrets.h` is ignored by Git. The example imports secret defaults only while
+the persisted Ethernet IP is empty. Later WebUI changes are therefore not
+overwritten on reboot.
+
+## Build and upload
+
+Run from the repository root:
+
+```powershell
+pio run -d examples/WT32-ETH01-v1.4 -e usb
+pio run -d examples/WT32-ETH01-v1.4 -e usb -t upload
+pio run -d examples/WT32-ETH01-v1.4 -e ota -t upload
+pio run -d examples/WT32-ETH01-v1.4 -e noota
+```
+
+## WT32-ETH01 UART and power
+
+USB serial flashing uses UART0:
+
+- adapter TX to board RX0/GPIO3
+- adapter RX to board TX0/GPIO1
+- adapter GND to board GND
+- hold GPIO0 low while resetting to enter the ROM bootloader
+
+The unnumbered RXD/TXD pins are UART2 on GPIO5/GPIO17 and cannot be used by
+`esptool` for ROM flashing.
+
+[WARNING] Use 3.3 V UART logic. Power the WT32-ETH01 from one suitable 5 V or
+3.3 V supply rated for at least 500 mA; never drive both supply inputs. Share
+ground between the supply, module, and USB-to-TTL adapter. A repeated
+`Brownout detector was triggered` boot loop indicates an inadequate or
+unstable supply and should not be hidden by disabling brownout detection.
+
+## Related documentation
+
+- [Feature Flags](FEATURE_FLAGS.md)
+- [OTA](OTA.md)
+- [Security](SECURITY.md)
+- [Troubleshooting](TROUBLESHOOTING.md)
+
+## Method overview
+
+| Method | Description |
+| --- | --- |
+| `ConfigManager.startWebServerOnNetwork()` | Starts ConfigManager services on an already configured IP interface. |
+| `ConfigManager.setupOTA(hostname, password)` | Starts ArduinoOTA after the interface has an IP address. |
+| `ConfigManager.handleClient()` | Processes WebSocket, runtime, and OTA work from `loop()`. |

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -13,6 +13,9 @@ Starting with **v3.0.0**, the library no longer requires a list of `CM_ENABLE_*`
   - `CM_ENABLE_VERBOSE_LOGGING` (default: `0`)
   - `CM_DISABLE_GUI_LOGGING` (default: `0`)
   - `CM_LOGGING_LEVEL` (default: `CM_LOG_LEVEL_TRACE`, runtime/project logging cap)
+  - `CM_ENABLE_WIFI` (default: `1`)
+    - `1`: include ConfigManager WiFi connection, AP, and roaming support
+    - `0`: compile out ConfigManager WiFi support for externally managed networks such as Ethernet
   - `CM_ENABLE_OTA` (default: `1`)
   - `CM_ENABLE_SYSTEM_PROVIDER` (default: `1`)
   - `CM_ENABLE_SYSTEM_TIME` (default: `1`)
@@ -35,6 +38,11 @@ For real numbers, build your target with and without each flag and compare the f
 - `CM_ENABLE_OTA=0`
   - Flash/RAM: medium savings (removes OTA routes and handler code).
   - Behavior: OTA upload endpoint not available.
+
+- `CM_ENABLE_WIFI=0`
+  - Flash/RAM: removes ConfigManager WiFi manager, AP, roaming, captive-portal, and WiFi runtime paths.
+  - Behavior: the sketch must initialize its network interface and call `ConfigManager.startWebServerOnNetwork()` after it receives an IP address.
+  - Framework note: Ethernet event handling in Arduino-ESP32 2.x still uses generic APIs exposed through `WiFi.h`; this does not start the WiFi radio.
 
 - `CM_DISABLE_GUI_LOGGING=1`
   - Flash/RAM: small to medium savings (removes GUI log output, buffer, and WS log payload building).
@@ -79,5 +87,5 @@ OTA is convenient but has security implications:
 
 | Method | Overloads / Variants | Description | Notes |
 |---|---|---|---|
-| _none_ | - | Build-flag reference; no callable API methods in this document. | Compile-time options only. |
+| `startWebServerOnNetwork` | `()` | Starts ConfigManager services on a network interface initialized by the sketch. | Use after Ethernet or another external interface has an IP address. |
 

--- a/docs/FEATURE_FLAGS.md
+++ b/docs/FEATURE_FLAGS.md
@@ -38,11 +38,13 @@ For real numbers, build your target with and without each flag and compare the f
 - `CM_ENABLE_OTA=0`
   - Flash/RAM: medium savings (removes OTA routes and handler code).
   - Behavior: OTA upload endpoint not available.
+  - Partitioning: use a no-OTA partition table separately when the application should reclaim the second OTA slot (the WT32 example uses `no_ota.csv`).
 
 - `CM_ENABLE_WIFI=0`
   - Flash/RAM: removes ConfigManager WiFi manager, AP, roaming, captive-portal, and WiFi runtime paths.
   - Behavior: the sketch must initialize its network interface and call `ConfigManager.startWebServerOnNetwork()` after it receives an IP address.
   - Framework note: Ethernet event handling in Arduino-ESP32 2.x still uses generic APIs exposed through `WiFi.h`; this does not start the WiFi radio.
+  - Example: see `examples/WT32-ETH01-v1.4` and `docs/ETHERNET.md`.
 
 - `CM_DISABLE_GUI_LOGGING=1`
   - Flash/RAM: small to medium savings (removes GUI log output, buffer, and WS log payload building).
@@ -77,9 +79,9 @@ For real numbers, build your target with and without each flag and compare the f
 
 OTA is convenient but has security implications:
 
-- OTA uses plain HTTP. There is no TLS. Anyone on the same network can observe traffic.
+- WebUI OTA uses plain HTTP. There is no TLS. Anyone on the same network can observe traffic.
 - Use a strong OTA password and do not reuse it elsewhere.
-- Prefer OTA only on trusted LAN/VPN. Avoid open WiFi.
+- Prefer OTA only on a trusted LAN/VPN, whether the device uses WiFi or Ethernet.
 - If you do not need OTA in production, disable it (`CM_ENABLE_OTA=0`).
 - Settings UI password and OTA password are separate; set both if you expose OTA.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -6,7 +6,9 @@ If you prefer a full working project, open one of the example projects in `examp
 
 ## Examples: PlatformIO setup notes
 
-The examples are set up to use this repo as a local library via `lib_deps = file://../..` and keep build outputs outside the repository using per-example `build_dir` / `libdeps_dir` under `${sysenv.HOME}/.pio-build/...`.
+The examples use this repository as a local library via
+`lib_deps = symlink://../..`. Per-example `build_dir` and `libdeps_dir` values
+under `${sysenv.HOME}/.pio/CM/ex/...` keep build outputs outside the repository.
 
 Avoid using `lib_extra_dirs = ../..` for the workspace library. If a build ever seems to use stale local library code, run:
 
@@ -15,7 +17,8 @@ pio run -t clean
 pio run
 ```
 
-Some examples include a pre-build helper script `tools/pio_force_local_lib_refresh.py` to force PlatformIO to refresh the local `file://../..` library copy automatically. You can disable that behavior by setting `CM_PIO_NO_LIB_REFRESH=1`.
+Some examples include `tools/pio_force_local_lib_refresh.py` to refresh local
+library metadata automatically. Set `CM_PIO_NO_LIB_REFRESH=1` to disable it.
 
 ## Quick start (recommended)
 
@@ -29,6 +32,16 @@ pio run -d examples/minimal -e usb -t upload --upload-port COM5
 ```
 
 > Tip: You can also open `examples/minimal` directly as a PlatformIO project in VS Code.
+
+For a wired WT32-ETH01 project:
+
+```sh
+pio run -d examples/WT32-ETH01-v1.4 -e usb
+pio run -d examples/WT32-ETH01-v1.4 -e usb -t upload
+```
+
+See [Ethernet](ETHERNET.md) for static network settings, OTA, no-OTA builds,
+UART0 wiring, and power requirements.
 
 ## Minimal pattern (ESPAsyncWebServer)
 
@@ -124,13 +137,13 @@ void setup()
 
     if (wifiSettings.wifiSsid.get().length() == 0)
     {
-        Serial.printf("[WARNING] SETUP: SSID is empty! [%s]\n", wifiSettings.wifiSsid.get().c_str());
+        Serial.printf("[W] SSID empty: %s\n", wifiSettings.wifiSsid.get().c_str());
         cfg.startAccessPoint();
     }
 
     if (WiFi.getMode() == WIFI_AP)
     {
-        Serial.println("[INFO] AP Mode");
+        Serial.println("[I] AP mode");
         return;
     }
 
@@ -159,19 +172,17 @@ void setup()
         cfg.setupOTA("esp32", "otapassword123");
     }
 
-    Serial.printf("[INFO] Webserver running at: %s\n", WiFi.localIP().toString().c_str());
+    Serial.printf("[I] Web server: %s\n", WiFi.localIP().toString().c_str());
 }
 
 void loop()
 {
+    cfg.getWiFiManager().update();
     cfg.handleClient();
-    cfg.handleWebsocketPush();
-    cfg.handleOTA();
-    cfg.updateLoopTiming();
 
     if (WiFi.status() != WL_CONNECTED && WiFi.getMode() != WIFI_AP)
     {
-        Serial.println("[WARNING] WiFi lost, reconnecting...");
+        Serial.println("[W] WiFi lost, reconnecting");
         cfg.reconnectWifi();
         delay(1500);
         cfg.setupOTA("esp32", "otapassword123");
@@ -187,6 +198,7 @@ void loop()
 ## Next
 
 - WiFi details and best practices: see `docs/WIFI.md`
+- Ethernet and WT32-ETH01: see `docs/ETHERNET.md`
 - OTA and Web UI flashing: see `docs/OTA.md`
 - GUI runtime (live, styling, theming): see `docs/GUI-Runtime.md`
 - Settings and OptionGroup patterns: see `docs/SETTINGS.md`
@@ -196,6 +208,7 @@ void loop()
 | Method | Overloads / Variants | Description | Notes |
 |---|---|---|---|
 | `ConfigManager.startWebServer` | `startWebServer()`<br>`startWebServer(const String& ssid, const String& password)`<br>`startWebServer(const IPAddress& staticIP, const IPAddress& gateway, const IPAddress& subnet, const String& ssid, const String& password, const IPAddress& dns1 = IPAddress(), const IPAddress& dns2 = IPAddress())` | Starts WiFi + web server using settings, DHCP, or static IP. | Core startup method family. |
+| `ConfigManager.startWebServerOnNetwork` | `startWebServerOnNetwork()` | Starts WebUI/runtime/OTA services on an IP interface initialized by the sketch. | Call after Ethernet or another external interface receives an IP address. |
 | `ConfigManager.handleClient` | `handleClient()` | Processes HTTP/WebSocket/runtime events. | Call in `loop()`. |
-| `ConfigManager.setupOTA` | `setupOTA(const String& hostname, const String& password = "")` | Enables OTA update handling after WiFi connect. | Optional for development and field updates. |
+| `ConfigManager.setupOTA` | `setupOTA(const String& hostname, const String& password = "")` | Enables OTA update handling after the active interface receives an IP address. | Works with WiFi or Ethernet. |
 

--- a/docs/OTA.md
+++ b/docs/OTA.md
@@ -2,6 +2,9 @@
 
 This document describes OTA update support and the Web UI firmware flashing workflow.
 
+OTA requires an IP connection but is not tied to WiFi. Call
+`ConfigManager.setupOTA()` after WiFi or Ethernet has received an IP address.
+
 ## Web UI flashing
 
 The embedded single-page app exposes a `Flash` action beside the `Settings` tab.
@@ -22,6 +25,38 @@ Workflow:
 - The backend remains asynchronous (`ESPAsyncWebServer`).
 - The `/ota_update` handler streams chunks into the Arduino `Update` API while performing password checks.
 
+## PlatformIO ArduinoOTA uploads
+
+An `espota` environment can upload over WiFi or Ethernet:
+
+```ini
+[env:ota]
+upload_protocol = espota
+upload_port = 192.168.2.127
+upload_flags =
+    -a
+    ota-password
+    -t
+    30
+```
+
+`-a` supplies the ArduinoOTA password and `-t` sets the timeout in seconds.
+Keep the password synchronized with the firmware setting. Do not specify both
+`-a` and `--auth` for the same upload.
+
+To remove OTA support from a firmware build:
+
+```ini
+[env:noota]
+board_build.partitions = no_ota.csv
+build_flags =
+    ${env.build_flags}
+    -DCM_ENABLE_OTA=0
+```
+
+The build flag removes ConfigurationsManager OTA code. The partition setting is
+separate and reclaims the second OTA application slot.
+
 Uploads are rejected when:
 
 - OTA is disabled
@@ -32,22 +67,22 @@ Uploads are rejected when:
 
 The runtime JSON includes OTA status information used by the Web UI:
 
-- `runtime.system.allowOTA`: true when OTA is enabled on the device (HTTP endpoint ready)
-- `runtime.system.otaActive`: true after `ArduinoOTA.begin()` has run (informational)
+- `runtime.system.otaActive`: true while an ArduinoOTA or WebUI firmware upload is active
+- `runtime.system.otaHasPassword`: true when an OTA password is configured
 
 See also `docs/GUI-Runtime.md`.
 
 ## Notes
 
 - ConfigurationsManager serves the UI/API over plain HTTP only.
-- If you need transport security, provide it externally (VPN, trusted WiFi only, or a TLS reverse proxy that terminates HTTPS).
+- If you need transport security, provide it externally (VPN, trusted LAN, or a TLS reverse proxy that terminates HTTPS).
 - See `docs/SECURITY.md` for details.
 
 ## Method overview
 
 | Method | Overloads / Variants | Description | Notes |
 |---|---|---|---|
-| `ConfigManager.setupOTA` | `setupOTA(const String& hostname, const String& password = "")` | Initializes ArduinoOTA endpoint and callbacks. | Usually called after WiFi connect. |
+| `ConfigManager.setupOTA` | `setupOTA(const String& hostname, const String& password = "")` | Initializes ArduinoOTA endpoint and callbacks. | Call after the active IP interface is ready. |
 | `ConfigManager.handleOTA` | `handleOTA()` | Processes OTA runtime events. | Must run regularly in `loop()`. |
 | `ConfigManager.enableOTA` | `enableOTA(bool enabled = true)` | Enables/disables OTA handling at runtime. | Runtime control for OTA availability. |
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -29,13 +29,14 @@ If you need HTTPS/TLS, the recommended approach is to terminate TLS externally (
 ## Recommendations
 
 - Use the UI only on a trusted network.
-- If you need TLS, provide it externally (e.g. VPN, WiFi isolation + trusted clients, or a reverse proxy that terminates HTTPS).
+- If you need TLS, provide it externally (e.g. VPN, network isolation with trusted clients, or a reverse proxy that terminates HTTPS).
 - Treat OTA/MQTT passwords as sensitive and keep them unique per device/project.
 
 ## Related Documentation
 
 - [Settings Configuration](SETTINGS.md)
 - [Feature Flags](FEATURE_FLAGS.md)
+- [Ethernet](ETHERNET.md)
 - [Smart WiFi Roaming](SMART_ROAMING.md)
 
 ## Method overview

--- a/docs/SETTINGS_STRUCTURE_PATTERN.md
+++ b/docs/SETTINGS_STRUCTURE_PATTERN.md
@@ -219,9 +219,9 @@ Guru Meditation Error: Core 1 panic'ed (LoadProhibited)
 
 ```cpp
 void init() {
-    Serial.println("[DEBUG] Initializing YourSettings...");
+    Serial.println("[D] Initializing settings");
     ConfigManager.addSetting(&yourBoolSetting);
-    Serial.println("[DEBUG] YourSettings initialized successfully");
+    Serial.println("[I] Settings initialized");
 }
 ```
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -27,7 +27,7 @@ pio run -e usb
 
 ### Example builds use old local library code
 
-If you are using `lib_deps = file://../..` and a build still behaves like it is using an older library snapshot, clean the example build and rebuild:
+If you are using `lib_deps = symlink://../..` and a build still behaves like it is using older library metadata, clean the example build and rebuild:
 
 ```sh
 pio run -t clean
@@ -46,6 +46,26 @@ pio run -e usb -t upload
 ```
 
 WARNING: `erase` deletes all flash data on the device.
+
+### WT32-ETH01: no serial data during upload
+
+`Failed to connect to ESP32: No serial data received` means `esptool` opened
+the COM port but received no ROM bootloader response.
+
+- Use UART0: adapter TX to RX0/GPIO3 and adapter RX to TX0/GPIO1.
+- Do not use the unnumbered UART2 pins on GPIO5/GPIO17.
+- Hold GPIO0 low while resetting or powering up.
+- Use 3.3 V UART logic and a shared ground.
+
+### WT32-ETH01: repeated brownout resets
+
+`Brownout detector was triggered` indicates that the module supply is dropping
+below the safe operating voltage. Use one stable 5 V or 3.3 V supply rated for
+at least 500 mA, keep wiring short, and share ground with the serial adapter.
+Do not power both module supply inputs and do not disable brownout detection to
+hide an unstable supply.
+
+See [Ethernet](ETHERNET.md) for the complete WT32 setup.
 
 ## check the meta data
 

--- a/examples/SolarInverterLimiter/platformio.ini
+++ b/examples/SolarInverterLimiter/platformio.ini
@@ -74,7 +74,7 @@ upload_port = 192.168.2.122
 
 upload_flags =
     -a
-    otaSI
+    ota1234
     -t
     30
 

--- a/examples/WT32-ETH01-v1.4/README.md
+++ b/examples/WT32-ETH01-v1.4/README.md
@@ -1,0 +1,43 @@
+# WT32-ETH01 V1.4 Ethernet Example
+
+This example is based on `examples/minimal` and targets the Wireless-Tag
+WT32-ETH01 V1.4 (WT32-S1). ConfigManager WiFi support is compiled out and the
+WebUI is served through the LAN8720 Ethernet interface at `192.168.2.127/24`.
+
+## Network configuration
+
+- Address: `192.168.2.127`
+- Netmask: `255.255.255.0`
+- Gateway: `192.168.2.1`
+- Primary DNS: `192.168.2.1`
+- WebUI: `http://192.168.2.127/`
+
+OTA is IP-based and remains enabled for the `usb` and `ota` environments. The
+`noota` environment removes ConfigManager OTA support and uses `no_ota.csv`.
+
+## Build and upload
+
+Run from the repository root:
+
+```bash
+pio run -d examples/WT32-ETH01-v1.4 -e usb
+pio run -d examples/WT32-ETH01-v1.4 -e usb -t upload
+pio run -d examples/WT32-ETH01-v1.4 -e ota -t upload
+pio run -d examples/WT32-ETH01-v1.4 -e noota
+```
+
+The default OTA password is `ota`. Change `OTA_PASSWORD` and the matching
+`upload_flags` value before using this outside a trusted network.
+
+## USB-to-TTL wiring
+
+Use 3.3 V UART logic levels. Flashing uses UART0, not the unnumbered UART2 pins:
+
+- Adapter TX to board RX0 (GPIO3)
+- Adapter RX to board TX0 (GPIO1)
+- Adapter GND to board GND
+- Hold GPIO0 low while resetting or powering up to enter the bootloader
+
+[WARNING] A USB-to-TTL adapter's 3.3 V regulator may not provide enough current
+for the ESP32 and Ethernet PHY. If boot or upload is unstable, use a suitable
+external supply with a shared ground while keeping UART logic at 3.3 V.

--- a/examples/WT32-ETH01-v1.4/README.md
+++ b/examples/WT32-ETH01-v1.4/README.md
@@ -8,9 +8,20 @@ WebUI is served through the LAN8720 Ethernet interface at `192.168.2.127/24`.
 
 - Address: `192.168.2.127`
 - Netmask: `255.255.255.0`
-- Gateway: `192.168.2.1`
-- Primary DNS: `192.168.2.1`
+- Gateway: configurable; tracked default `192.168.2.1`
+- Primary DNS: configurable; tracked default `192.168.2.1`
 - WebUI: `http://192.168.2.127/`
+
+Ethernet IP, netmask, gateway, DNS, Settings password, OTA password, and NTP
+configuration are persisted and available in the WebUI. Ethernet address
+changes take effect after a reboot. NTP servers and timezone are applied at
+network startup; the interval field is stored while ESP32 SNTP handles its own
+periodic resynchronization.
+
+Copy `src/secret/secrets.example.h` to `src/secret/secrets.h` for local
+first-run defaults. The local file is ignored by Git. Secret defaults are
+imported only while the persisted Ethernet IP is empty, so later WebUI changes
+are not overwritten on reboot.
 
 OTA is IP-based and remains enabled for the `usb` and `ota` environments. The
 `noota` environment removes ConfigManager OTA support and uses `no_ota.csv`.
@@ -26,8 +37,9 @@ pio run -d examples/WT32-ETH01-v1.4 -e ota -t upload
 pio run -d examples/WT32-ETH01-v1.4 -e noota
 ```
 
-The default OTA password is `ota`. Change `OTA_PASSWORD` and the matching
-`upload_flags` value before using this outside a trusted network.
+The example uses `--auth=...`; `-a` is the equivalent short form and `-t` sets
+an optional timeout. Keep the firmware `OTA_PASSWORD` and PlatformIO
+authentication value synchronized. Do not specify both authentication forms.
 
 ## USB-to-TTL wiring
 
@@ -39,5 +51,6 @@ Use 3.3 V UART logic levels. Flashing uses UART0, not the unnumbered UART2 pins:
 - Hold GPIO0 low while resetting or powering up to enter the bootloader
 
 [WARNING] A USB-to-TTL adapter's 3.3 V regulator may not provide enough current
-for the ESP32 and Ethernet PHY. If boot or upload is unstable, use a suitable
-external supply with a shared ground while keeping UART logic at 3.3 V.
+for the ESP32 and Ethernet PHY. Use one suitable 5 V or 3.3 V supply rated for
+at least 500 mA, never drive both supply inputs, and share ground while keeping
+UART logic at 3.3 V. Repeated brownout resets indicate an unstable supply.

--- a/examples/WT32-ETH01-v1.4/platformio.ini
+++ b/examples/WT32-ETH01-v1.4/platformio.ini
@@ -36,7 +36,7 @@ upload_speed = 115200
 [env:ota]
 upload_protocol = espota
 upload_port = 192.168.2.127
-upload_flags = --auth=ota
+upload_flags = --auth=ota1234
 
 [env:noota]
 upload_protocol = esptool

--- a/examples/WT32-ETH01-v1.4/platformio.ini
+++ b/examples/WT32-ETH01-v1.4/platformio.ini
@@ -1,0 +1,49 @@
+; PlatformIO configuration for the Wireless-Tag WT32-ETH01 V1.4 (WT32-S1).
+
+[platformio]
+description = ConfigurationsManager Ethernet example for WT32-ETH01 V1.4
+default_envs = usb
+build_dir = ${sysenv.HOME}/.pio/CM/ex/WT32-ETH01-v1.4
+libdeps_dir = ${sysenv.HOME}/.pio/CM/ex/WT32-ETH01-v1.4/libdeps
+
+[env]
+platform = espressif32
+board = wt32-eth01
+framework = arduino
+monitor_speed = 115200
+build_unflags = -std=gnu++11
+build_flags =
+	-Wno-deprecated-declarations
+	-std=gnu++17
+	-DCM_ENABLE_WIFI=0
+	-DCM_ENABLE_LOGGING=0
+	-DCM_ENABLE_VERBOSE_LOGGING=0
+extra_scripts =
+	pre:../../tools/pio_force_local_lib_refresh.py
+	pre:../../tools/preCompile_script.py
+lib_deps =
+	bblanchon/ArduinoJson@~7.4.3
+	esphome/ESPAsyncWebServer-esphome@~3.4.0
+	esphome/AsyncTCP-esphome@2.1.4
+	symlink://../..
+
+[env:usb]
+upload_protocol = esptool
+upload_port = COM6
+monitor_port = COM6
+upload_speed = 115200
+
+[env:ota]
+upload_protocol = espota
+upload_port = 192.168.2.127
+upload_flags = --auth=ota
+
+[env:noota]
+upload_protocol = esptool
+upload_port = COM6
+monitor_port = COM6
+upload_speed = 115200
+board_build.partitions = no_ota.csv
+build_flags =
+	${env.build_flags}
+	-DCM_ENABLE_OTA=0

--- a/examples/WT32-ETH01-v1.4/src/main.cpp
+++ b/examples/WT32-ETH01-v1.4/src/main.cpp
@@ -4,6 +4,10 @@
 #include "ConfigManager.h"
 #include "core/CoreSettings.h"
 
+#if __has_include("secret/secrets.h")
+#include "secret/secrets.h"
+#endif
+
 #define VERSION CONFIGMANAGER_VERSION
 
 #ifndef APP_NAME
@@ -18,18 +22,101 @@
 #define OTA_PASSWORD "ota"
 #endif
 
+#ifndef MY_ETHERNET_IP
+#define MY_ETHERNET_IP "192.168.2.127"
+#endif
+
+#ifndef MY_GATEWAY_IP
+#define MY_GATEWAY_IP "192.168.2.1"
+#endif
+
+#ifndef MY_SUBNET_MASK
+#define MY_SUBNET_MASK "255.255.255.0"
+#endif
+
+#ifndef MY_DNS_IP
+#define MY_DNS_IP MY_GATEWAY_IP
+#endif
+
 namespace
 {
-const IPAddress localIp(192, 168, 2, 127);
-const IPAddress gateway(192, 168, 2, 1);
-const IPAddress subnet(255, 255, 255, 0);
-const IPAddress dnsPrimary(192, 168, 2, 1);
-
 volatile bool ethernetHasIp = false;
 bool networkServicesStarted = false;
 
 cm::CoreSettings &coreSettings = cm::CoreSettings::instance();
 cm::CoreSystemSettings &systemSettings = coreSettings.system;
+cm::CoreNtpSettings &ntpSettings = coreSettings.ntp;
+
+Config<String> ethernetIp{ConfigOptions<String>{.key = "EthIP", .name = "IP Address", .category = "Ethernet", .defaultValue = String(""), .showInWeb = true, .sortOrder = 1}};
+Config<String> ethernetSubnet{ConfigOptions<String>{.key = "EthSubnet", .name = "Subnet Mask", .category = "Ethernet", .defaultValue = String(""), .showInWeb = true, .sortOrder = 2}};
+Config<String> ethernetGateway{ConfigOptions<String>{.key = "EthGateway", .name = "Gateway", .category = "Ethernet", .defaultValue = String(""), .showInWeb = true, .sortOrder = 3}};
+Config<String> ethernetDns{ConfigOptions<String>{.key = "EthDNS", .name = "Primary DNS", .category = "Ethernet", .defaultValue = String(""), .showInWeb = true, .sortOrder = 4}};
+Config<String> settingsPassword{ConfigOptions<String>{.key = "SettingsPass", .name = "Settings Password", .category = "System", .defaultValue = String(""), .showInWeb = true, .isPassword = true, .sortOrder = 2}};
+
+void registerSettings()
+{
+    ConfigManager.setCategoryLayoutOverride("Ethernet", "Network", "Network", "Ethernet Settings", 10);
+    ConfigManager.addSettingsPage("Network", 10);
+    ConfigManager.addSettingsGroup("Network", "Network", "Ethernet Settings", 10);
+
+    ConfigManager.addSetting(&ethernetIp);
+    ConfigManager.addSetting(&ethernetSubnet);
+    ConfigManager.addSetting(&ethernetGateway);
+    ConfigManager.addSetting(&ethernetDns);
+    ConfigManager.addSetting(&settingsPassword);
+
+    coreSettings.attachSystem(ConfigManager);
+    coreSettings.attachNtp(ConfigManager);
+}
+
+void setupDefaults()
+{
+    if (ethernetIp.get().isEmpty())
+    {
+        ethernetIp.set(MY_ETHERNET_IP);
+        ethernetSubnet.set(MY_SUBNET_MASK);
+        ethernetGateway.set(MY_GATEWAY_IP);
+        ethernetDns.set(MY_DNS_IP);
+        settingsPassword.set(SETTINGS_PASSWORD);
+#if CM_ENABLE_OTA
+        systemSettings.otaPassword.set(OTA_PASSWORD);
+#endif
+#ifdef MY_NTP_SERVER_1
+        ntpSettings.server1.set(MY_NTP_SERVER_1);
+#endif
+#ifdef MY_NTP_SERVER_2
+        ntpSettings.server2.set(MY_NTP_SERVER_2);
+#endif
+#ifdef MY_NTP_TIMEZONE
+        ntpSettings.tz.set(MY_NTP_TIMEZONE);
+#endif
+        ConfigManager.saveAll();
+    }
+
+    ConfigManager.setSettingsPassword(settingsPassword.get());
+    settingsPassword.setCallback([](const String &password)
+        { ConfigManager.setSettingsPassword(password); });
+}
+
+bool loadEthernetConfig(IPAddress &localIp, IPAddress &gateway, IPAddress &subnet, IPAddress &dnsPrimary)
+{
+    const bool valid = localIp.fromString(ethernetIp.get()) &&
+                       gateway.fromString(ethernetGateway.get()) &&
+                       subnet.fromString(ethernetSubnet.get()) &&
+                       dnsPrimary.fromString(ethernetDns.get());
+    if (!valid)
+    {
+        Serial.println("[E] Invalid Ethernet network settings");
+    }
+    return valid;
+}
+
+void setupNtp()
+{
+    configTzTime(ntpSettings.tz.get().c_str(),
+                 ntpSettings.server1.get().c_str(),
+                 ntpSettings.server2.get().c_str());
+}
 
 void onNetworkEvent(WiFiEvent_t event)
 {
@@ -81,23 +168,24 @@ void setup()
     ConfigManager.setAppTitle(APP_NAME);
     ConfigManager.setVersion(VERSION);
     ConfigManager.enableBuiltinSystemProvider();
-    ConfigManager.setSettingsPassword(SETTINGS_PASSWORD);
-
-    coreSettings.attachSystem(ConfigManager);
+    registerSettings();
     ConfigManager.loadAll();
-
-#if CM_ENABLE_OTA
-    if (systemSettings.otaPassword.get() != OTA_PASSWORD)
-    {
-        systemSettings.otaPassword.save(OTA_PASSWORD);
-    }
-#endif
+    setupDefaults();
 
     WiFi.onEvent(onNetworkEvent);
 
     if (!ETH.begin())
     {
         Serial.println("[E] Ethernet PHY init failed");
+        return;
+    }
+
+    IPAddress localIp;
+    IPAddress gateway;
+    IPAddress subnet;
+    IPAddress dnsPrimary;
+    if (!loadEthernetConfig(localIp, gateway, subnet, dnsPrimary))
+    {
         return;
     }
 
@@ -115,6 +203,7 @@ void loop()
 #if CM_ENABLE_OTA
         ConfigManager.setupOTA(APP_NAME, systemSettings.otaPassword.get());
 #endif
+        setupNtp();
         networkServicesStarted = true;
     }
 

--- a/examples/WT32-ETH01-v1.4/src/main.cpp
+++ b/examples/WT32-ETH01-v1.4/src/main.cpp
@@ -1,0 +1,123 @@
+#include <Arduino.h>
+#include <ETH.h>
+
+#include "ConfigManager.h"
+#include "core/CoreSettings.h"
+
+#define VERSION CONFIGMANAGER_VERSION
+
+#ifndef APP_NAME
+#define APP_NAME "CM-WT32-ETH01"
+#endif
+
+#ifndef SETTINGS_PASSWORD
+#define SETTINGS_PASSWORD ""
+#endif
+
+#ifndef OTA_PASSWORD
+#define OTA_PASSWORD "ota"
+#endif
+
+namespace
+{
+const IPAddress localIp(192, 168, 2, 127);
+const IPAddress gateway(192, 168, 2, 1);
+const IPAddress subnet(255, 255, 255, 0);
+const IPAddress dnsPrimary(192, 168, 2, 1);
+
+volatile bool ethernetHasIp = false;
+bool networkServicesStarted = false;
+
+cm::CoreSettings &coreSettings = cm::CoreSettings::instance();
+cm::CoreSystemSettings &systemSettings = coreSettings.system;
+
+void onNetworkEvent(WiFiEvent_t event)
+{
+    switch (event)
+    {
+    case ARDUINO_EVENT_ETH_START:
+        ETH.setHostname(APP_NAME);
+        Serial.println("[I] Ethernet started");
+        break;
+    case ARDUINO_EVENT_ETH_CONNECTED:
+        Serial.println("[I] Ethernet link connected");
+        break;
+    case ARDUINO_EVENT_ETH_GOT_IP:
+        ethernetHasIp = true;
+        Serial.printf("[I] Ethernet ready: http://%s\n", ETH.localIP().toString().c_str());
+        break;
+#if ESP_ARDUINO_VERSION_MAJOR >= 3
+    case ARDUINO_EVENT_ETH_LOST_IP:
+        ethernetHasIp = false;
+        Serial.println("[W] Ethernet lost IP");
+        break;
+#endif
+    case ARDUINO_EVENT_ETH_DISCONNECTED:
+        ethernetHasIp = false;
+        Serial.println("[W] Ethernet disconnected");
+        break;
+    case ARDUINO_EVENT_ETH_STOP:
+        ethernetHasIp = false;
+        Serial.println("[W] Ethernet stopped");
+        break;
+    default:
+        break;
+    }
+}
+}
+
+void setup()
+{
+    Serial.begin(115200);
+    delay(200);
+
+    ConfigManagerClass::setLogger([](const char *message)
+        {
+            Serial.print("[CM] ");
+            Serial.println(message);
+        });
+
+    ConfigManager.setAppName(APP_NAME);
+    ConfigManager.setAppTitle(APP_NAME);
+    ConfigManager.setVersion(VERSION);
+    ConfigManager.enableBuiltinSystemProvider();
+    ConfigManager.setSettingsPassword(SETTINGS_PASSWORD);
+
+    coreSettings.attachSystem(ConfigManager);
+    ConfigManager.loadAll();
+
+#if CM_ENABLE_OTA
+    if (systemSettings.otaPassword.get() != OTA_PASSWORD)
+    {
+        systemSettings.otaPassword.save(OTA_PASSWORD);
+    }
+#endif
+
+    WiFi.onEvent(onNetworkEvent);
+
+    if (!ETH.begin())
+    {
+        Serial.println("[E] Ethernet PHY init failed");
+        return;
+    }
+
+    if (!ETH.config(localIp, gateway, subnet, dnsPrimary))
+    {
+        Serial.println("[E] Ethernet static IP config failed");
+    }
+}
+
+void loop()
+{
+    if (ethernetHasIp && !networkServicesStarted)
+    {
+        ConfigManager.startWebServerOnNetwork();
+#if CM_ENABLE_OTA
+        ConfigManager.setupOTA(APP_NAME, systemSettings.otaPassword.get());
+#endif
+        networkServicesStarted = true;
+    }
+
+    ConfigManager.handleClient();
+    delay(1);
+}

--- a/examples/WT32-ETH01-v1.4/src/secret/secrets.example.h
+++ b/examples/WT32-ETH01-v1.4/src/secret/secrets.example.h
@@ -1,0 +1,18 @@
+#pragma once
+
+// Copy this file to secrets.h and adjust values.
+// NOTE: secrets.h must stay out of version control.
+
+#define APP_NAME "CM-WT32-ETH01"
+
+#define MY_ETHERNET_IP "192.168.2.127"
+#define MY_GATEWAY_IP "192.168.2.1"
+#define MY_SUBNET_MASK "255.255.255.0"
+#define MY_DNS_IP "192.168.2.1"
+
+#define SETTINGS_PASSWORD "cm"
+#define OTA_PASSWORD "ota1234"
+
+#define MY_NTP_SERVER_1 "pool.ntp.org"
+#define MY_NTP_SERVER_2 "time.nist.gov"
+#define MY_NTP_TIMEZONE "CET-1CEST,M3.5.0/02,M10.5.0/03"

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32 Configuration Manager",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "keywords": "esp32, configuration, configurations, config, config-manager, configuration-manager, settings, settings-manager, wifi, wi-fi, web-server, web-ui, ota, nvs, preferences, iot, automation",
   "description": "Robust ESP32 config and configuration manager with web UI, WiFi setup, OTA, and persistent settings via NVS/Preferences.",
   "repository": {

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32 Configuration Manager",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "keywords": "esp32, configuration, configurations, config, config-manager, configuration-manager, settings, settings-manager, wifi, wi-fi, web-server, web-ui, ota, nvs, preferences, iot, automation",
   "description": "Robust ESP32 config and configuration manager with web UI, WiFi setup, OTA, and persistent settings via NVS/Preferences.",
   "repository": {

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -8,7 +8,6 @@
 #include <vector>
 #include <functional>
 #include <memory>
-#include <WiFi.h>
 #include <ArduinoJson.h>
 #include <type_traits>
 #include <AsyncTCP.h>
@@ -24,10 +23,16 @@
 
 #include "ConfigManagerConfig.h"
 
+#if CM_ENABLE_WIFI
+#include <WiFi.h>
+#endif
+
 #include "io/ioDefinitions.h"
 
 // Modular components
+#if CM_ENABLE_WIFI
 #include "wifi/WiFiManager.h"
+#endif
 #include "web/WebServer.h"
 #include "ota/OTAManager.h"
 #include "runtime/RuntimeManager.h"
@@ -44,7 +49,7 @@ public:
 };
 #endif
 
-#define CONFIGMANAGER_VERSION "4.2.3" // Synced to library.json
+#define CONFIGMANAGER_VERSION "4.3.0" // Synced to library.json
 
 static constexpr uint32_t CM_WS_PUSH_INTERVAL_DEFAULT_MS = 5000;
 static constexpr uint32_t CM_WS_PUSH_INTERVAL_MIN_MS = 550;
@@ -1839,7 +1844,9 @@ private:
         }
 
         // Modular components
+#if CM_ENABLE_WIFI
     ConfigManagerWiFi wifiManager;
+#endif
     ConfigManagerWeb webManager;
     ConfigManagerOTA otaManager;
     ConfigManagerRuntime runtimeManager;
@@ -2513,6 +2520,28 @@ public:
         CM_CORE_LOG("[I] Settings password configured");
     }
 
+    // Start ConfigManager services on a network interface initialized by the sketch.
+    // This is used for Ethernet or other IP transports when ConfigManager does not own WiFi.
+    void startWebServerOnNetwork()
+    {
+        webManager.begin(this);
+        otaManager.begin(this);
+        runtimeManager.begin(this);
+        WebSocketPush(true);
+        setPushOnConnect(true);
+
+        if (BaseSetting *otaEnable = findSettingByKeyHint("System", "OTAEn"); otaEnable && otaEnable->getType() == SettingType::BOOL)
+        {
+            otaManager.enable(static_cast<Config<bool> *>(otaEnable)->get());
+        }
+
+        otaManager.setupWebRoutes(webManager.getServer());
+        webManager.defineAllRoutes();
+        CM_CORE_LOG("[I] ConfigManager services started on external network");
+    }
+
+#if CM_ENABLE_WIFI
+
     bool hasValidStationCredentials(const String &ssid, const String &password, const char *context = nullptr)
     {
         const char *ctx = (context && context[0]) ? context : "startWebServer";
@@ -2816,6 +2845,8 @@ public:
         otaManager.setupWebRoutes(webManager.getServer());
     }
 
+#endif // CM_ENABLE_WIFI
+
     // Non-blocking client handling
     void handleClient()
     {
@@ -2824,9 +2855,11 @@ public:
         handleOTA();
     }
 
+#if CM_ENABLE_WIFI
     // WiFi status and control
     bool getWiFiStatus() { return wifiManager.isConnected(); }
     void reconnectWifi() { wifiManager.reconnect(); }
+#endif
 
     // System control
     void reboot()
@@ -3340,11 +3373,14 @@ public:
     void triggerLoggerTest() { CM_CORE_LOG("[I] Logger test message"); }
 
     // Access to modules for advanced usage
+#if CM_ENABLE_WIFI
     ConfigManagerWiFi &getWiFiManager() { return wifiManager; }
+#endif
     ConfigManagerWeb &getWebManager() { return webManager; }
     ConfigManagerOTA &getOTAManager() { return otaManager; }
     ConfigManagerRuntime &getRuntimeManager() { return runtimeManager; }
 
+#if CM_ENABLE_WIFI
     // Smart WiFi Roaming configuration - convenience methods
     void enableSmartRoaming(bool enable = true) { wifiManager.enableSmartRoaming(enable); }
     void setRoamingThreshold(int thresholdDbm = -75) { wifiManager.setRoamingThreshold(thresholdDbm); }
@@ -3362,6 +3398,7 @@ public:
     bool isMacPriorityEnabled() const { return wifiManager.isMacPriorityEnabled(); }
     String getFilterMac() const { return wifiManager.getFilterMac(); }
     String getPriorityMac() const { return wifiManager.getPriorityMac(); }
+#endif
 
 public:
     static LogCallback logger;

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -49,7 +49,7 @@ public:
 };
 #endif
 
-#define CONFIGMANAGER_VERSION "4.3.0" // Synced to library.json
+#define CONFIGMANAGER_VERSION "4.4.0" // Synced to library.json
 
 static constexpr uint32_t CM_WS_PUSH_INTERVAL_DEFAULT_MS = 5000;
 static constexpr uint32_t CM_WS_PUSH_INTERVAL_MIN_MS = 550;

--- a/src/ConfigManagerConfig.h
+++ b/src/ConfigManagerConfig.h
@@ -7,6 +7,7 @@
 // - CM_ENABLE_LOGGING (0)
 // - CM_ENABLE_VERBOSE_LOGGING (0)
 // - CM_DISABLE_GUI_LOGGING (0)
+// - CM_ENABLE_WIFI (1)
 // - CM_ENABLE_OTA (1)
 // - CM_ENABLE_SYSTEM_PROVIDER (1)
 // - CM_ENABLE_SYSTEM_TIME (1)
@@ -47,6 +48,10 @@
 
 #ifndef CM_ENABLE_OTA
 #define CM_ENABLE_OTA 1
+#endif
+
+#ifndef CM_ENABLE_WIFI
+#define CM_ENABLE_WIFI 1
 #endif
 
 // --- Core/library logging flags (still configurable) ---

--- a/src/core/CoreSettings.h
+++ b/src/core/CoreSettings.h
@@ -28,6 +28,7 @@ inline constexpr char IO[] = "IO";
 inline constexpr char Ntp[] = "NTP";
 }
 
+#if CM_ENABLE_WIFI
 struct CoreWiFiSettings
 {
     Config<String> wifiSsid{ConfigOptions<String>{.key = "WiFiSSID", .name = "WiFi SSID", .category = CoreCategories::WiFi, .defaultValue = String(""), .showInWeb = true, .sortOrder = 1}};
@@ -67,6 +68,7 @@ struct CoreWiFiSettings
         { return !useDhcp.get(); };
     }
 };
+#endif
 
 struct CoreSystemSettings
 {
@@ -150,11 +152,14 @@ public:
     // Attach all core settings bundles.
     void attach(ConfigManagerClass &cfg)
     {
+#if CM_ENABLE_WIFI
         attachWiFi(cfg);
+#endif
         attachSystem(cfg);
         attachButtons(cfg);
     }
 
+#if CM_ENABLE_WIFI
     void attachWiFi(ConfigManagerClass &cfg,
                     const char* pageName = CoreCategories::WiFi,
                     const char* groupPretty = "WiFi Settings",
@@ -166,6 +171,7 @@ public:
         wifi.attachTo(cfg);
         wifiAttached = true;
     }
+#endif
 
     void attachSystem(ConfigManagerClass &cfg,
                       const char* pageName = CoreCategories::System,
@@ -201,7 +207,9 @@ public:
         ntpAttached = true;
     }
 
+#if CM_ENABLE_WIFI
     CoreWiFiSettings wifi;
+#endif
     CoreButtonSettings buttons;
     CoreSystemSettings system{String(CONFIGMANAGER_VERSION)};
     CoreNtpSettings ntp;
@@ -209,7 +217,9 @@ public:
 private:
     CoreSettings() = default;
 
+#if CM_ENABLE_WIFI
     bool wifiAttached = false;
+#endif
     bool systemAttached = false;
     bool buttonsAttached = false;
     bool ntpAttached = false;

--- a/src/ota/OTAManager.cpp
+++ b/src/ota/OTAManager.cpp
@@ -80,11 +80,6 @@ void ConfigManagerOTA::setup(const String& hostname, const String& password) {
     otaHostname = hostname;
     otaPassword = password;
 
-    if (WiFi.status() != WL_CONNECTED) {
-        OTA_LOG("WiFi not connected, skipping OTA setup");
-        return;
-    }
-
     if (!otaInitialized) {
         ArduinoOTA.setHostname(otaHostname.c_str());
 

--- a/src/ota/OTAManager.h
+++ b/src/ota/OTAManager.h
@@ -1,10 +1,14 @@
 #pragma once
 
+#include "../ConfigManagerConfig.h"
+
+#if CM_ENABLE_OTA
 #include <ArduinoOTA.h>
 #include <Update.h>
+#endif
+
 #include <ESPAsyncWebServer.h>
 #include <functional>
-#include "../ConfigManagerConfig.h"
 
 // Forward declaration
 class ConfigManagerClass;

--- a/src/runtime/RuntimeManager.cpp
+++ b/src/runtime/RuntimeManager.cpp
@@ -623,6 +623,7 @@ void ConfigManagerRuntime::enableBuiltinSystemProvider() {
         obj["usedHeap"] = ESP.getHeapSize() - ESP.getFreeHeap();
         obj["heapFragmentation"] = 100 - (ESP.getMaxAllocHeap() * 100) / ESP.getFreeHeap();
 
+#if CM_ENABLE_WIFI
         if (WiFi.status() == WL_CONNECTED) {
             int rssi = WiFi.RSSI();
             obj["rssi"] = rssi;
@@ -642,6 +643,15 @@ void ConfigManagerRuntime::enableBuiltinSystemProvider() {
             obj["routerMAC"] = "00:00:00:00:00:00";
             obj["channel"] = 0;
         }
+#else
+        obj["rssi"] = 0;
+        obj["rssiTxt"] = rssiQualityText(-100);
+        obj["wifiConnected"] = false;
+        obj["localIP"] = "0.0.0.0";
+        obj["gateway"] = "0.0.0.0";
+        obj["routerMAC"] = "00:00:00:00:00:00";
+        obj["channel"] = 0;
+#endif
 
         obj["cpuFreqMHz"] = ESP.getCpuFreqMHz();
         obj["flashSize"] = ESP.getFlashChipSize();

--- a/src/web/WebServer.cpp
+++ b/src/web/WebServer.cpp
@@ -969,6 +969,7 @@ void ConfigManagerWeb::handleCaptivePortalProbe(AsyncWebServerRequest* request) 
 }
 
 bool ConfigManagerWeb::isCaptivePortalMode() const {
+#if CM_ENABLE_WIFI
     if (configManager && configManager->getWiFiManager().isInAPMode()) {
         return true;
     }
@@ -979,6 +980,9 @@ bool ConfigManagerWeb::isCaptivePortalMode() const {
     }
 
     return mode == WIFI_AP_STA && WiFi.status() != WL_CONNECTED;
+#else
+    return false;
+#endif
 }
 
 bool ConfigManagerWeb::shouldRedirectToPortal(AsyncWebServerRequest* request) const {

--- a/src/wifi/WiFiManager.cpp
+++ b/src/wifi/WiFiManager.cpp
@@ -1,3 +1,7 @@
+#include "../ConfigManagerConfig.h"
+
+#if CM_ENABLE_WIFI
+
 #include "WiFiManager.h"
 #include "../ConfigManager.h"
 #include <ESP.h>
@@ -1320,3 +1324,5 @@ void ConfigManagerWiFi::logNoSsidAvailScan_() {
   noSsidScanStartMillis = now;
   (void)WiFi.scanNetworks(true /*async*/, true /*showHidden*/);
 }
+
+#endif // CM_ENABLE_WIFI

--- a/src/wifi/WiFiManager.h
+++ b/src/wifi/WiFiManager.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "../ConfigManagerConfig.h"
+
+#if CM_ENABLE_WIFI
+
 #include <WiFi.h>
 #include <functional>
-#include "../ConfigManagerConfig.h"
 
 // WiFi connection states
 enum WiFiManagerState {
@@ -163,3 +166,5 @@ public:
   // Compatibility methods for ConfigManager
   bool getStatus() const { return isConnected(); }
 };
+
+#endif // CM_ENABLE_WIFI

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "esp32-config-webui",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "esp32-config-webui",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "dependencies": {
         "vue": "^3.5.38"
       },

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "esp32-config-webui",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "esp32-config-webui",
-      "version": "4.2.3",
+      "version": "4.3.0",
       "dependencies": {
         "vue": "^3.5.38"
       },

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esp32-config-webui",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esp32-config-webui",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "private": true,
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- add optional ConfigManager WiFi compile-out and external-network startup
- add a WT32-ETH01 V1.4 Ethernet example with persisted network, password, NTP, OTA, and no-OTA settings
- document Ethernet, OTA, feature flags, security, setup, and troubleshooting
- align package and WebUI release metadata at version 4.4.0
- align SolarInverterLimiter espota authentication

## Validation
- `pio run -e usb`
- `pio run -e usb -e ota -e noota` in `examples/WT32-ETH01-v1.4`
- `pio project config` in `examples/SolarInverterLimiter`
- `git diff --check`
- successful WT32 serial upload over COM6 before the metadata-only version adjustment