### PR TITLE
chore: consolidate dependency maintenance and CI ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,21 +231,21 @@ More:
 ### The embedded Web UI automatically adapts to desktop and mobile devices.
 
 >Current UI snapshots
->![alt text](examples/screenshots/V4.0.0-GUI-STD.jpg)
->![alt text](examples/screenshots/V4.0.0-GUI-Dark.jpg)
+>![alt text](https://raw.githubusercontent.com/vitalyruhl/ConfigurationsManager/main/examples/screenshots/V4.0.0-GUI-STD.jpg)
+>![alt text](https://raw.githubusercontent.com/vitalyruhl/ConfigurationsManager/main/examples/screenshots/V4.0.0-GUI-Dark.jpg)
 
 > Example on Monitor HD
-> ![Example on Monitor HD](examples/screenshots/test-hd.jpg)
+> ![Example on Monitor HD](https://raw.githubusercontent.com/vitalyruhl/ConfigurationsManager/main/examples/screenshots/test-hd.jpg)
 > Example on mobile
-> ![Example on mobile](examples/screenshots/test-mobile.jpg)
+> ![Example on mobile](https://raw.githubusercontent.com/vitalyruhl/ConfigurationsManager/main/examples/screenshots/test-mobile.jpg)
 > Settings on HD
-> ![Settings on HD 1](examples/screenshots/test-settings-HD.jpg)
-> ![Settings on HD 2](examples/screenshots/test-settings2-HD.jpg)
+> ![Settings on HD 1](https://raw.githubusercontent.com/vitalyruhl/ConfigurationsManager/main/examples/screenshots/test-settings-HD.jpg)
+> ![Settings on HD 2](https://raw.githubusercontent.com/vitalyruhl/ConfigurationsManager/main/examples/screenshots/test-settings2-HD.jpg)
 > Settings on mobile
-> ![Settings on mobile 1](examples/screenshots/test-settings-mobile.jpg)
-> ![Settings on mobile 2](examples/screenshots/test-settings-mobile2.jpg)
+> ![Settings on mobile 1](https://raw.githubusercontent.com/vitalyruhl/ConfigurationsManager/main/examples/screenshots/test-settings-mobile.jpg)
+> ![Settings on mobile 2](https://raw.githubusercontent.com/vitalyruhl/ConfigurationsManager/main/examples/screenshots/test-settings-mobile2.jpg)
 > Darkmode
-> ![Darkmode](examples/screenshots/cm-full-io-demo-gui-darkmode.jpg)
+> ![Darkmode](https://raw.githubusercontent.com/vitalyruhl/ConfigurationsManager/main/examples/screenshots/cm-full-io-demo-gui-darkmode.jpg)
 
 ## Version History
 

--- a/tools/build/run-full-repository-gate.ps1
+++ b/tools/build/run-full-repository-gate.ps1
@@ -196,13 +196,13 @@ try {
         $embeddedTestTargets = @($matrix | Where-Object HasEmbeddedTests)
         $webUiTests = @(Get-ChildItem -Path (Join-Path $repoRoot 'webui\test') -Filter '*.test.mjs' -File -ErrorAction SilentlyContinue | Sort-Object FullName)
         Add-Plan @('Format and precommit checks', 'Cppcheck', 'Working tree after static checks', 'Temporary content policy', 'PowerShell syntax', 'Agent governance generator', 'Serena memory generator', 'Workflow structure')
-        foreach ($target in $matrix) {
-            $relativeDirectory = [IO.Path]::GetRelativePath($repoRoot, $target.ProjectDirectory).Replace('\', '/')
-            Add-Plan "PlatformIO build $relativeDirectory [$($target.Environment)]"
-        }
         foreach ($target in $embeddedTestTargets) {
             $relativeDirectory = [IO.Path]::GetRelativePath($repoRoot, $target.ProjectDirectory).Replace('\', '/')
             Add-Plan "PlatformIO test compile $relativeDirectory [$($target.Environment)]"
+        }
+        foreach ($target in $matrix) {
+            $relativeDirectory = [IO.Path]::GetRelativePath($repoRoot, $target.ProjectDirectory).Replace('\', '/')
+            Add-Plan "PlatformIO build $relativeDirectory [$($target.Environment)]"
         }
         if (Test-Path -LiteralPath (Join-Path $repoRoot 'webui\package.json')) {
             Add-Plan 'WebUI production build'
@@ -233,15 +233,15 @@ try {
             }
             if ($gateExitCode -eq 0) {
                 if (-not (Get-Command pio -ErrorAction SilentlyContinue)) { throw 'PlatformIO CLI `pio` is required for the full repository gate.' }
-                foreach ($target in $matrix) {
-                    $relativeDirectory = [IO.Path]::GetRelativePath($repoRoot, $target.ProjectDirectory).Replace('\', '/')
-                    if (-not (Run-RequiredCheck -Name "PlatformIO build $relativeDirectory [$($target.Environment)]" -Action { pio run -d $target.ProjectDirectory -e $target.Environment })) { break }
-                }
-            }
-            if ($gateExitCode -eq 0) {
                 foreach ($target in $embeddedTestTargets) {
                     $relativeDirectory = [IO.Path]::GetRelativePath($repoRoot, $target.ProjectDirectory).Replace('\', '/')
                     if (-not (Run-RequiredCheck -Name "PlatformIO test compile $relativeDirectory [$($target.Environment)]" -Action { pio test -d $target.ProjectDirectory -e $target.Environment --without-uploading --without-testing })) { break }
+                }
+            }
+            if ($gateExitCode -eq 0) {
+                foreach ($target in $matrix) {
+                    $relativeDirectory = [IO.Path]::GetRelativePath($repoRoot, $target.ProjectDirectory).Replace('\', '/')
+                    if (-not (Run-RequiredCheck -Name "PlatformIO build $relativeDirectory [$($target.Environment)]" -Action { pio run -d $target.ProjectDirectory -e $target.Environment })) { break }
                 }
             }
             if ($gateExitCode -eq 0 -and (Test-Path -LiteralPath (Join-Path $repoRoot 'webui\package.json'))) {

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -3302,9 +3302,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -2690,9 +2690,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -3000,9 +3000,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3019,7 +3019,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Scope

- Supersedes Dependabot PRs #70 and #72 with their reviewed lockfile-only updates.
- Runs the complete embedded PlatformIO test matrix before any `pio run` example or environment build.
- Uses absolute Raw GitHub screenshot URLs so the README renders on both GitHub and the PlatformIO Registry.

## Dependencies

- `shell-quote` 1.8.4 -> 1.10.0
- `postcss` 8.5.15 -> 8.5.23 (including its locked `nanoid` transitive update)

## Validation

- `npm ci --ignore-scripts` completed for each lockfile update.
- All nine screenshot URLs return `200 image/jpeg`.
- `pio pkg pack` contains `README.md` and the screenshot assets.
- Full local repository gate passed once on the combined final commit, with both PlatformIO test targets preceding every build target.

No version bump, tag, GitHub release, or PlatformIO publish is included.